### PR TITLE
implement catch parameter.

### DIFF
--- a/examples/trycatch.js
+++ b/examples/trycatch.js
@@ -1,38 +1,43 @@
 function tcf(j) {
-  for (var i = 0; i < 7; i++) {
+  for (i = 0; i < 7; i++) {
     console.log("  i=" + i)
+    var that = this
     try {
       if (i >= 1) {
         var str = "thrown in try: i=" + i
         console.log("   ", str)
         throw str
       }
-      console.log("    try(inner)")
-    } catch (e) {
+      console.log("    try(inner)      arg[0]=", arguments[0], this === that)
+    } catch (ex) {
+      console.log("    error obj=", ex)
       if (i == 2 && j == 0) {
         var str = "thrown in catch: i=" + i
         console.log("   ", str)
         throw str
       }
-      console.log("    catch(inner)")
+      console.log("    (in catch) i:", i, "j:", j)
+      console.log("    catch(inner)    arg[0]=", arguments[0], this === that)
+      //arguments[0] = 100
     } finally {
       if (i == 3) {
         var str = "thrown in finally: i=" + i
         console.log("   ", str)
         throw str
       }
-      console.log("    finally(inner)")
+      console.log("    finally(inner)  arg[0]=", arguments[0], this === that)
     }
   }
 }
 
 for (var j = 0; j < 2; j++) {
   console.log("j=" + j)
+  var that = this;
   try {
     tcf(j)
-    console.log("try(outer)")
+    console.log("try(outer)", that === this)
   } catch (e) {
-    console.log("catch(outer)")
+    console.log("catch(outer) error obj=", e, that === this)
   }
 }
 


### PR DESCRIPTION
Now, catch parameter and block scope in catch clause are available.

limitations:
In catch clause, function arguments can be get, but can not be changed through arguments[].

here is a test code.
```javascript
function func(a, b, c) {
  var str = "arguments = [ "
  for (var i = 0; i < 3; i++) {
    str += arguments[i] + " "
  }
  str += "]"
  console.log("[a, b, c] = [", a, b, c, "]")
  console.log(str)
  try {
    arguments[0] = 100
    throw "error"
  } catch(ex) {
    arguments[1] = 200
  } finally {
    var str = "arguments = [ "
    for (var i = 0; i < 3; i++) {
      str += arguments[i] + " "
    }
    str += "]"
    console.log("[a, b, c] = [", a, b, c, "]")
    console.log(str)
  }
}

function p(ary) {
  var str = ""
  for (var i = 0; i < 3; i++) {
    str += arguments[i] + " "
  }
  console.log(str)
}

func(0, 1, 2)
```
```
(node.js)
[a, b, c] = [ 0 1 2 ]
arguments = [ 0 1 2 ]
[a, b, c] = [ 100 200 2 ]
arguments = [ 100 200 2 ]

(current implementation of rapidus)
[a, b, c] = [ 0 1 2 ]
arguments = [ 0 1 2 ]
[a, b, c] = [ 100 1 2 ]
arguments = [ 100 1 2 ]
```