### PR TITLE
bug fix:

### DIFF
--- a/examples/test.js
+++ b/examples/test.js
@@ -1,0 +1,5 @@
+var ex = 0
+try {
+  throw 100
+} catch (ex) {}
+console.log(ex)

--- a/src/vm_codegen.rs
+++ b/src/vm_codegen.rs
@@ -648,6 +648,7 @@ impl VMCodeGen {
 
         let catch_pos = iseq.len() as isize;
         self.bytecode_gen.gen_catch(iseq);
+        self.bytecode_gen.gen_push_scope(iseq);
         match &param.base {
             NodeBase::Identifier(param_name) => {
                 self.bytecode_gen.gen_decl_var(&param_name, iseq);
@@ -660,7 +661,7 @@ impl VMCodeGen {
         self.level.push(Level::Catch {
             return_instr_pos: vec![],
         });
-        self.bytecode_gen.gen_push_scope(iseq);
+
         self.run(catch, iseq, false)?;
         self.bytecode_gen.gen_pop_scope(iseq);
         let catch_ = self.level.pop().unwrap();


### PR DESCRIPTION
```
$ node examples/test.js
0
(before fix)
$ cargo run examples/test.js
    Finished dev [unoptimized + debuginfo] target(s) in 0.27s
     Running `target/debug/rapidus examples/test.js`
100
(after fix)
$ cargo run examples/test.js
    Finished dev [unoptimized + debuginfo] target(s) in 8.54s
     Running `target/debug/rapidus examples/test.js`
0
```