### PR TITLE
add assert feature in JS. multi-lined REPL.

### DIFF
--- a/assert.js
+++ b/assert.js
@@ -1,0 +1,7 @@
+module.exports = {
+  deepEqual: function(x, y) {
+    // JIT in module cause LLVM error.
+    console.log("assert_seq " + x + " " + y)
+    __assert(x, y)
+  }
+}

--- a/examples/fact.js
+++ b/examples/fact.js
@@ -1,5 +1,10 @@
 function fact(n) {
-  if (n < 2) { return 1 } else { return n * fact(n - 1) }
+  if (n < 2) {
+    return 1
+  } else {
+    return n * fact(n - 1)
+  }
 }
 
-console.log("fact(20) =", fact(20))
+var assert = require('assert').deepEqual
+assert(fact(20), 479001600)

--- a/src/gc.rs
+++ b/src/gc.rs
@@ -231,15 +231,15 @@ pub fn mark_and_sweep(vm: &mut VM) {
         true
     }
 
-    if over16kb_allocated() {
+    if vm.gc_on && over16kb_allocated() {
         let _sw = Stopwatch::start_new();
         let mut marked = FxHashSet::default();
         let _pre_alloc_size = ALLOCATED_MEM_SIZE_BYTE.load(atomic::Ordering::SeqCst);
         let _pre_gc_size = GC_MEM.with(|mem| mem.borrow_mut().len());
         trace(vm, &mut marked);
         free(&marked);
+        println!("GC executed: {} ms", _sw.elapsed_ms());
         /*
-        println!("GC executed: {} ms", sw.elapsed_ms());
         let post_gc_size = GC_MEM.with(|mem| mem.borrow_mut().len());
         if pre_gc_size != post_gc_size {
             println!(

--- a/src/gc.rs
+++ b/src/gc.rs
@@ -234,26 +234,20 @@ pub fn mark_and_sweep(vm: &mut VM) {
     if vm.gc_on && over16kb_allocated() {
         let _sw = Stopwatch::start_new();
         let mut marked = FxHashSet::default();
-        let _pre_alloc_size = ALLOCATED_MEM_SIZE_BYTE.load(atomic::Ordering::SeqCst);
-        let _pre_gc_size = GC_MEM.with(|mem| mem.borrow_mut().len());
+        let pre_alloc_size = ALLOCATED_MEM_SIZE_BYTE.load(atomic::Ordering::SeqCst);
+        let pre_gc_size = GC_MEM.with(|mem| mem.borrow_mut().len());
         trace(vm, &mut marked);
         free(&marked);
         if vm.is_debug {
-            println!("GC executed: {} ms", _sw.elapsed_ms());
-        }
-        /*
-        let post_gc_size = GC_MEM.with(|mem| mem.borrow_mut().len());
-        if pre_gc_size != post_gc_size {
             println!(
-                "\nallocated_size: {}->{} marked: {} all:{}->{}",
+                "GC executed: pause duration {} ms. {} -> {} bytes. {} => {} objects",
+                _sw.elapsed_ms(),
                 pre_alloc_size,
                 ALLOCATED_MEM_SIZE_BYTE.load(atomic::Ordering::SeqCst),
-                marked.len(),
                 pre_gc_size,
-                post_gc_size,
+                GC_MEM.with(|mem| mem.borrow_mut().len()),
             );
         }
-        */
     }
 }
 

--- a/src/gc.rs
+++ b/src/gc.rs
@@ -238,7 +238,9 @@ pub fn mark_and_sweep(vm: &mut VM) {
         let _pre_gc_size = GC_MEM.with(|mem| mem.borrow_mut().len());
         trace(vm, &mut marked);
         free(&marked);
-        println!("GC executed: {} ms", _sw.elapsed_ms());
+        if vm.is_debug {
+            println!("GC executed: {} ms", _sw.elapsed_ms());
+        }
         /*
         let post_gc_size = GC_MEM.with(|mem| mem.borrow_mut().len());
         if pre_gc_size != post_gc_size {
@@ -256,7 +258,7 @@ pub fn mark_and_sweep(vm: &mut VM) {
 }
 
 fn trace(vm: &mut VM, marked: &mut FxHashSet<GcPtr>) {
-    for val in &mut vm.const_table.value {
+    for val in &mut vm.codegen.bytecode_gen.const_table.value {
         val.trace(marked);
     }
     //let after_const = marked.len();

--- a/src/main.rs
+++ b/src/main.rs
@@ -278,20 +278,25 @@ fn run(file_name: &str, trace: bool) {
 
 #[test]
 fn vm_test() {
-    // IMPORTANT: these test should be run in a single thread.
-    use rapidus::test::{execute_script, test_code, test_file};
+    // IMPORTANT: these tests should be run in a single thread.
+    use rapidus::test::{assert_file, execute_script, test_code, test_file};
     execute_script("for(var i = 0; i < 4; i++){ i }".to_string(), true);
-    test_file(
-        "trinity".to_string(),
-        "[true,true,true,true,true,true]".to_string(),
-    );
-    test_file("closure".to_string(), "[0,50,1,50,1,1000,50]".to_string());
-    test_file("fact".to_string(), "[479001600]".to_string());
+    assert_file("trinity".to_string());
+    assert_file("closure".to_string());
+    assert_file("fact".to_string());
     test_file(
         "array".to_string(),
-        "[1,2,3,4,[3,4],[2,3,'three1',5],4,[1,2,'three']]".to_string(),
+        "'2,3,6,7,3,4,2,3,three1,5,4,1,2,three'".to_string(),
     );
     test_code("(100).toString(15)".to_string(), "'6a'".to_string());
+    test_code(
+        "'死して屍拾う者なし'[4]".to_string(),
+        "'拾'".to_string(),
+    );
+    test_code(
+        "'死して屍拾う者なし'.length".to_string(),
+        "9".to_string(),
+    );
     test_file(
         "label".to_string(),
         "[0,0,0,1,0,2,1,0,2,0,2,1,2,2]".to_string(),
@@ -306,7 +311,7 @@ fn vm_test() {
         "qsort".to_string(),
         "[ 0, 0, 1, 3, 5, 7, 7, 10, 11, 12, 14, 14, 16, 17, 19 ]".to_string(),
     );
-    test_file("arguments1".to_string(), "[[1,2,3,4],[1,2,[3,4]],[5,6,7,undefined],[5,6,[7]],[8,9,undefined,undefined],[8,9,undefined],[10,undefined,undefined,undefined],[10,undefined,undefined]]".to_string());
+    test_file("arguments1".to_string(), "[[1,2,3,4,4],[1,2,[3,4]],[5,6,7,undefined,3],[5,6,[7]],[8,9,undefined,undefined,2],[8,9,undefined],[10,undefined,undefined,undefined,1],[10,undefined,undefined]]".to_string());
     test_file(
         "arguments2".to_string(),
         "[10,15,20,25,15,10,'OK',20,25,'OK',10,'NG',20,25,'NG']".to_string(),

--- a/src/test.rs
+++ b/src/test.rs
@@ -4,7 +4,6 @@ use std::fs::OpenOptions;
 use std::io::Read;
 use vm;
 use vm::value;
-use vm_codegen::VMCodeGen;
 
 pub fn test_file(file_name: String, answer: String) {
     println!("{}", format!("test/{}.js", file_name));
@@ -36,16 +35,13 @@ pub fn test_code(code: String, answer: String) {
 }
 
 pub fn execute_script(text: String, debug: bool) -> String {
-    let mut vm_codegen = VMCodeGen::new();
-    let global = vm_codegen.global_varmap.clone();
-    let mut vm = vm::vm::VM::new(global);
+    let mut vm = vm::vm::VM::new();
 
     let mut parser = parser::Parser::new(text);
     let node = parser.parse_all().unwrap();
     let mut iseq = vec![];
 
-    vm_codegen.compile(&node, &mut iseq, true).unwrap();
-    vm.const_table = vm_codegen.bytecode_gen.const_table;
+    vm.codegen.compile(&node, &mut iseq, true).unwrap();
     vm.is_debug = debug;
     vm.run(iseq).unwrap();
     vm.state

--- a/src/test.rs
+++ b/src/test.rs
@@ -7,6 +7,16 @@ use vm::value;
 use vm_codegen::VMCodeGen;
 
 pub fn test_file(file_name: String, answer: String) {
+    println!("{}", format!("test/{}.js", file_name));
+    compare_scripts(load_file(file_name), answer);
+}
+
+pub fn assert_file(file_name: String) {
+    println!("{}", format!("test/{}.js", file_name));
+    execute_script(load_file(file_name), false);
+}
+
+fn load_file(file_name: String) -> String {
     let mut file_body = String::new();
     match OpenOptions::new()
         .read(true)
@@ -18,8 +28,7 @@ pub fn test_file(file_name: String, answer: String) {
         },
         Err(_) => panic!("file not found"),
     };
-    println!("{}", format!("test/{}.js", file_name));
-    compare_scripts(file_body, answer);
+    file_body
 }
 
 pub fn test_code(code: String, answer: String) {

--- a/src/vm_codegen.rs
+++ b/src/vm_codegen.rs
@@ -52,8 +52,7 @@ pub struct VMCodeGen {
 }
 
 impl VMCodeGen {
-    pub fn new() -> VMCodeGen {
-        let global = CallObject::new_global();
+    pub fn new(global: CallObjectRef) -> VMCodeGen {
         VMCodeGen {
             global_varmap: global,
             func_header_info: vec![vec![]],

--- a/test/arguments1.js
+++ b/test/arguments1.js
@@ -1,6 +1,6 @@
 var a = []
 function f (x, y, ...z) {
-  a.push([arguments[0],arguments[1],arguments[2],arguments[3]])
+  a.push([arguments[0],arguments[1],arguments[2],arguments[3],arguments.length])
   a.push([x, y, z])
 }
 

--- a/test/array.js
+++ b/test/array.js
@@ -1,8 +1,8 @@
 var a = [1, 2, 'three', 4]
 var b = []
 function A(x, y) {
-  this.x = x
-  this.y = y
+  this.x = x * 2
+  this.y = x + y
 }
 function B() {
   A.call(this, 1, 2)
@@ -22,5 +22,5 @@ b.push(
 )
 b.push(a.pop())
 b.push(a)
-console.log(b)
-b
+console.log(b.toString())
+b.toString()

--- a/test/closure.js
+++ b/test/closure.js
@@ -1,6 +1,6 @@
-var ans = []
+var assert = require('assert').deepEqual
 count = 1000
-var module = (function() {
+var mod = (function() {
   var count = 0
   return {
     count: 50,
@@ -8,18 +8,19 @@ var module = (function() {
       count++
     },
     show: function() {
-      ans.push(count, this.count)
+      return count
     },
     nest: function() {
       return this.count
     }
   }
 })()
-var f = module.show
-module.show() // 0
-module.increment()
-module.show() // 1
-f()
-ans.push(module.nest())
-console.log(ans)
-ans
+var f = mod.show
+var g = mod.nest
+assert(mod.show(), 0)
+mod.increment()
+assert(mod.show(), 1)
+assert(mod.nest(), 50)
+assert(f(), 1)
+assert(g(), 1000)
+assert(mod.nest(), 50)

--- a/test/fact.js
+++ b/test/fact.js
@@ -1,8 +1,6 @@
 function fact(n) {
   if (n < 2) { return 1 } else { return n * fact(n - 1) }
 }
-var a = []
-var f = fact(12)
-console.log(f)
-a.push(f)
-a
+
+var assert = require('assert').deepEqual
+assert(fact(12), 479001600)

--- a/test/trinity.js
+++ b/test/trinity.js
@@ -1,9 +1,10 @@
-var a = []
-a.push([] == 0)
-a.push('0' == 0)
-a.push('\t' == 0)
-a.push([] != '0')
-a.push('0' != '\t')
-a.push('\t' != [])
-console.log(a)
-a
+var assert = require('assert').deepEqual
+
+assert([] == 0, true)
+assert('0' == 0, true)
+assert('\t' == 0, true)
+assert([] != '0', true)
+assert('0' != '\t', true)
+assert('\t' != [], true)
+
+


### PR DESCRIPTION
1. Add a built-in function ("__assert()") for assertion.
Using "assert.js" module allows node.js-compatible assert in rapidus.

test.js
```javascript
var assert = require('assert').deepEqual
assert([] == 0, true)
// assert(left, right) raise runtime error when left !== right.
// Remember assert() is a strict equality comparison,
// which means assert([], 0) raise a runtime error.
```
assert.js
```javascript
module.exports = {
  deepEqual: function(x, y) {
    console.log("assert_seq " + x + " " + y)
    __assert(x, y)
  }
}
```

2. Improve an idiom to create and execute VM.
```Rust
let mut vm = vm::vm::VM::new();
// VM::new() automatically create VMCodegen and BytecodeGen,
// and set a link for const_table and global_varmap between them.
let mut iseq = vec![];
match vm.codegen.compile(&node, &mut iseq, false) {
// Now, VMCodegen and BytecodeGen can be reffered from VM.
    Ok(()) => {}
    Err(_) => { /* some error handling */}
}
vm.run(iseq)?
```

3. Add multi-lined input feature for REPL. This can recognize the input is whether multi-lined or not (like node.js REPL).
```
> function fib(x) {
... if (x < 2) return x
... return fib(x-1) + fib(x-2)
... }
undefined
> fib(10)
55
```

4. Refine codes for require(). Modules become to be executed on the same VM as main script.
