### PR TITLE
support "x => {}" style arrow function syntax.

### DIFF
--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -84,14 +84,6 @@ impl Lexer {
     pub fn is_empty(&self) -> bool {
         self.token_pos >= self.buf.len()
     }
-
-    pub fn save_state(&mut self) {
-        self.states.push(self.token_pos);
-    }
-
-    pub fn restore_state(&mut self) {
-        self.token_pos = self.states.pop().unwrap();
-    }
 }
 
 impl Lexer {
@@ -112,6 +104,20 @@ impl Lexer {
                 return Ok(tok);
             }
         }
+    }
+
+    /// Skip line terminators.
+    /// Return Err(Error::NormalEOF) when reached EOF.
+    pub fn skip_lineterminator(&mut self) -> Result<(), Error> {
+        let len = self.buf.len();
+        for i in self.token_pos..len {
+            let tok = self.buf[i].clone();
+            if tok.kind != Kind::LineTerminator {
+                self.token_pos = i;
+                return Ok(());
+            }
+        }
+        Err(Error::NormalEOF)
     }
 
     /// Peek the next token.

--- a/src/main.rs
+++ b/src/main.rs
@@ -288,6 +288,13 @@ mod tests {
 
     #[test]
     fn arrow_function() {
-        test_code("let f = (x) => { return x * x }; f(5)".to_string(), "25".to_string());
+        test_code(
+            "let f = (x) => { return x * x }; f(5)".to_string(),
+            "25".to_string(),
+        );
+        test_code(
+            "let f = x => { return x * x }; f(6)".to_string(),
+            "36".to_string(),
+        );
     }
 }


### PR DESCRIPTION
1. A variant of an arrow function was supported.
```Rust
let f = x => x * x
```
2. _ExpressionStatement_ needs trailing semicolon or line terminator.
http://www.ecma-international.org/ecma-262/9.0/index.html#prod-ExpressionStatement
```Rust
1 + 2 3  // Syntax Error
2 * 5 // OK
1; 2 + 5; 3 // OK
```
3. Tests added.