### PR TITLE
Improve parsing call-, member-, new-expression.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -312,4 +312,9 @@ mod tests {
     fn env() {
         assert_file("env")
     }
+
+    #[test]
+    fn new_call_member() {
+        assert_file("new_call_member")
+    }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -906,7 +906,6 @@ impl Parser {
         } else {
             self.read_primary_expression()?
         };
-        println!("PE/ME {:?}", lhs);
         while let Ok(tok) = self.lexer.next_skip_lineterminator() {
             let pos_ = self.lexer.get_current_pos();
             match tok.kind {

--- a/test/new_call_member.js
+++ b/test/new_call_member.js
@@ -1,0 +1,23 @@
+let assert = (n, l, r) => {
+  if (l !== r) {
+    throw n
+  }
+}
+let o = {
+  h: function(str) {
+    return str2 => {
+      return str + str2
+    }
+  }
+}
+assert(0, new f().g(), 'OK')
+assert(1, new o.h('O')('K'), 'OK')
+function f() {
+  this.name = 'OK'
+  this.g = function() {
+    return this.name
+  }
+  function g() {
+    return 'NG'
+  }
+}

--- a/test/new_call_member.js
+++ b/test/new_call_member.js
@@ -5,7 +5,7 @@ const assert = (n, l, r) => {
 }
 
 const o = {
-  h: function(str) {
+  f: function(str) {
     return str2 => {
       return str + str2
     }
@@ -22,5 +22,12 @@ function f() {
   }
 }
 
+let g = function(x) {
+  return function(y) {
+    return { ans: x * y }
+  }
+}
+
 assert(0, new f().g(), 'OK')
-assert(1, new o.h('O')('K'), 'OK')
+assert(1, new o.f('O')('K'), 'OK')
+assert(2, new new g(5)(4).ans, 20)

--- a/test/new_call_member.js
+++ b/test/new_call_member.js
@@ -1,17 +1,17 @@
-let assert = (n, l, r) => {
+const assert = (n, l, r) => {
   if (l !== r) {
     throw n
   }
 }
-let o = {
+
+const o = {
   h: function(str) {
     return str2 => {
       return str + str2
     }
   }
 }
-assert(0, new f().g(), 'OK')
-assert(1, new o.h('O')('K'), 'OK')
+
 function f() {
   this.name = 'OK'
   this.g = function() {
@@ -21,3 +21,6 @@ function f() {
     return 'NG'
   }
 }
+
+assert(0, new f().g(), 'OK')
+assert(1, new o.h('O')('K'), 'OK')


### PR DESCRIPTION
Expressions listed below are currently not parsed correctly.

```javascript
new f().g()
new o.f('O')('K')
new new g(5)(4).ans
```

This PR fix this problem, and tests added.