### PR TITLE
Proposal of refactoring

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,8 +13,8 @@ jobs:
           command: set -eux
       #- run:
       #    command: apt-get update
-      - run:
-          command: apt-get install -y libgtk-3-dev libfreetype6-dev libssl-dev pkg-config curl make build-essential
+      #- run:
+      #    command: apt-get install -y libgtk-3-dev libfreetype6-dev libssl-dev pkg-config curl make build-essential
       - run:
           command: |
             wget "https://static.rust-lang.org/rustup/dist/x86_64-unknown-linux-gnu/rustup-init"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,10 +11,10 @@ jobs:
       - checkout
       - run:
           command: set -eux
+      #- run:
+      #    command: apt-get update
       - run:
-          command: apt-get update
-      - run:
-          command: apt-get install -y libgtk-3-dev libfreetype6-dev zlib1g-dev wget libssl-dev pkg-config cmake zlib1g-dev curl binutils-dev libcurl4-openssl-dev libdw-dev libiberty-dev git cmake make build-essential
+          command: apt-get install -y libgtk-3-dev libfreetype6-dev libssl-dev pkg-config curl make build-essential
       - run:
           command: |
             wget "https://static.rust-lang.org/rustup/dist/x86_64-unknown-linux-gnu/rustup-init"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: ragnaroek/kcov:v31
+      - image: ragnaroek/kcov:v33
 
     working_directory: /opt/rapidus
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: ubuntu:16.04
+      - image: ragnaroek/kcov:v31
 
     working_directory: /opt/rapidus
 
@@ -25,22 +25,22 @@ jobs:
             chmod -R a+w $RUSTUP_HOME $CARGO_HOME;
             rm rustup-init
             source ~/.cargo/env
-      - run: 
+      - run:
           name: Install llvm-6.0 and so on
           command: |
             apt-get install clang-6.0 llvm-6.0 llvm-6.0-dev opt libedit-dev build-essential make -y
             # ln -s /usr/bin/clang-6.0 /usr/bin/clang; 
             # ln -s /usr/bin/clang++-6.0 /usr/bin/clang++; 
             ln -s /usr/bin/llvm-config-6.0 /usr/bin/llvm-config;
-      - run:
-          name: Setting up kcov
-          command: |
-            git clone https://github.com/SimonKagstrom/kcov
-            cd kcov
-            git checkout 9db5fa58986c2eae39e82580f15ba6fadb2dc906
-            cmake .
-            make -j
-            make install
+      #- run:
+      #    name: Setting up kcov
+      #    command: |
+      #      git clone https://github.com/SimonKagstrom/kcov
+      #      cd kcov
+      #      git checkout 9db5fa58986c2eae39e82580f15ba6fadb2dc906
+      #      cmake .
+      #      make -j
+      #      make install
       - run:
           name: Test
           command: |

--- a/src/builtins/array.rs
+++ b/src/builtins/array.rs
@@ -7,8 +7,10 @@ use vm::{
 };
 
 pub fn array(vm: &mut VM2) -> Value {
-    let ary = vm.builtin_function("Array".to_string(), array_constructor);
-    ary.set_property_by_string_key("prototype".to_string(), vm.object_prototypes.array);
+    let ary = vm
+        .factory
+        .builtin_function("Array".to_string(), array_constructor);
+    ary.set_property_by_string_key("prototype".to_string(), vm.factory.object_prototypes.array);
     ary.get_property_by_str_key("prototype")
         .set_constructor(ary);
     ary
@@ -64,7 +66,7 @@ pub fn array_prototype_map(vm: &mut VM2, args: &[Value], cur_frame: &Frame) -> V
         ));
     }
 
-    let array = vm.array(new_ary).clone();
+    let array = vm.factory.array(new_ary).clone();
     vm.stack.push(array.into());
 
     Ok(())

--- a/src/builtins/array.rs
+++ b/src/builtins/array.rs
@@ -1,22 +1,14 @@
-use gc;
 use vm::{
     error::RuntimeError,
     frame::Frame,
-    jsvalue::{object::Property, prototype::ObjectPrototypes, value::Value},
+    jsvalue::object::Property,
+    jsvalue::value::Value,
     vm::{VMResult, VM2},
 };
 
-pub fn array(
-    memory_allocator: &mut gc::MemoryAllocator,
-    object_prototypes: &ObjectPrototypes,
-) -> Value {
-    let ary = Value::builtin_function(
-        memory_allocator,
-        object_prototypes,
-        "Array".to_string(),
-        array_constructor,
-    );
-    ary.set_property_by_string_key("prototype".to_string(), object_prototypes.array);
+pub fn array(vm: &mut VM2) -> Value {
+    let ary = vm.builtin_function("Array".to_string(), array_constructor);
+    ary.set_property_by_string_key("prototype".to_string(), vm.object_prototypes.array);
     ary.get_property_by_str_key("prototype")
         .set_constructor(ary);
     ary
@@ -72,8 +64,8 @@ pub fn array_prototype_map(vm: &mut VM2, args: &[Value], cur_frame: &Frame) -> V
         ));
     }
 
-    vm.stack
-        .push(Value::array(&mut vm.memory_allocator, &vm.object_prototypes, new_ary).into());
+    let array = vm.array(new_ary).clone();
+    vm.stack.push(array.into());
 
     Ok(())
 }

--- a/src/builtins/console.rs
+++ b/src/builtins/console.rs
@@ -1,4 +1,12 @@
-use vm::{error::RuntimeError, frame::Frame, jsvalue::value::*, vm::VM2};
+use vm::{
+    error::RuntimeError,
+    frame::Frame,
+    jsvalue::object::Property,
+    jsvalue::value::{
+        AccessorProperty, DataProperty, ObjectKind2, Value, EMPTY, NULL, UNDEFINED, UNINITIALIZED,
+    },
+    vm::VM2,
+};
 
 pub fn console_log(vm: &mut VM2, args: &[Value], _cur_frame: &Frame) -> Result<(), RuntimeError> {
     let args_len = args.len();

--- a/src/builtins/function.rs
+++ b/src/builtins/function.rs
@@ -1,17 +1,8 @@
-use gc;
-use vm::{frame, jsvalue, jsvalue::value::Value, vm};
+use vm::{frame, jsvalue::value::Value, vm};
 
-pub fn function(
-    memory_allocator: &mut gc::MemoryAllocator,
-    object_prototypes: &jsvalue::prototype::ObjectPrototypes,
-) -> Value {
-    let func = Value::builtin_function(
-        memory_allocator,
-        object_prototypes,
-        "Function".to_string(),
-        function_constructor,
-    );
-    func.set_property_by_string_key("prototype".to_string(), object_prototypes.function);
+pub fn function(vm: &mut vm::VM2) -> Value {
+    let func = vm.builtin_function("Function".to_string(), function_constructor);
+    func.set_property_by_string_key("prototype".to_string(), vm.object_prototypes.function);
     func.get_property_by_str_key("prototype")
         .set_constructor(func);
     func

--- a/src/builtins/function.rs
+++ b/src/builtins/function.rs
@@ -1,8 +1,13 @@
 use vm::{frame, jsvalue::value::Value, vm};
 
 pub fn function(vm: &mut vm::VM2) -> Value {
-    let func = vm.builtin_function("Function".to_string(), function_constructor);
-    func.set_property_by_string_key("prototype".to_string(), vm.object_prototypes.function);
+    let func = vm
+        .factory
+        .builtin_function("Function".to_string(), function_constructor);
+    func.set_property_by_string_key(
+        "prototype".to_string(),
+        vm.factory.object_prototypes.function,
+    );
     func.get_property_by_str_key("prototype")
         .set_constructor(func);
     func

--- a/src/builtins/math.rs
+++ b/src/builtins/math.rs
@@ -10,9 +10,11 @@ use vm::{
 };
 
 pub fn math(vm: &mut vm::VM2) -> Value {
-    let math_random = vm.builtin_function("random".to_string(), math_random);
+    let math_random = vm
+        .factory
+        .builtin_function("random".to_string(), math_random);
 
-    make_normal_object!(vm.memory_allocator, vm.object_prototypes,
+    make_normal_object!(vm.factory,
         random => true, false, true: math_random
     )
 }

--- a/src/builtins/math.rs
+++ b/src/builtins/math.rs
@@ -1,9 +1,7 @@
-use gc::MemoryAllocator;
 use rand::random;
 use rustc_hash::FxHashMap;
 use vm::{
     frame,
-    jsvalue::prototype::ObjectPrototypes,
     jsvalue::{
         object::{DataProperty, ObjectInfo, ObjectKind2, Property},
         value::Value,
@@ -11,15 +9,10 @@ use vm::{
     vm,
 };
 
-pub fn math(memory_allocator: &mut MemoryAllocator, object_prototypes: &ObjectPrototypes) -> Value {
-    let math_random = Value::builtin_function(
-        memory_allocator,
-        object_prototypes,
-        "random".to_string(),
-        math_random,
-    );
+pub fn math(vm: &mut vm::VM2) -> Value {
+    let math_random = vm.builtin_function("random".to_string(), math_random);
 
-    make_normal_object!(memory_allocator, object_prototypes,
+    make_normal_object!(vm.memory_allocator, vm.object_prototypes,
         random => true, false, true: math_random
     )
 }

--- a/src/builtins/math.rs
+++ b/src/builtins/math.rs
@@ -3,7 +3,7 @@ use rustc_hash::FxHashMap;
 use vm::{
     frame,
     jsvalue::{
-        object::{DataProperty, ObjectInfo, ObjectKind2, Property},
+        object::{ObjectInfo, ObjectKind2},
         value::Value,
     },
     vm,

--- a/src/builtins/object.rs
+++ b/src/builtins/object.rs
@@ -1,18 +1,9 @@
-use gc;
 use rustc_hash::FxHashMap;
 use vm::{frame, jsvalue::value::*, vm};
 
-pub fn object(
-    memory_allocator: &mut gc::MemoryAllocator,
-    object_prototypes: &ObjectPrototypes,
-) -> Value {
-    let obj = Value::builtin_function(
-        memory_allocator,
-        object_prototypes,
-        "Object".to_string(),
-        object_constructor,
-    );
-    obj.set_property_by_string_key("prototype".to_string(), object_prototypes.object);
+pub fn object(vm: &mut vm::VM2) -> Value {
+    let obj = vm.builtin_function("Object".to_string(), object_constructor);
+    obj.set_property_by_string_key("prototype".to_string(), vm.object_prototypes.object);
     obj.get_property_by_str_key("prototype")
         .set_constructor(obj);
     obj

--- a/src/builtins/object.rs
+++ b/src/builtins/object.rs
@@ -2,8 +2,10 @@ use rustc_hash::FxHashMap;
 use vm::{frame, jsvalue::value::*, vm};
 
 pub fn object(vm: &mut vm::VM2) -> Value {
-    let obj = vm.builtin_function("Object".to_string(), object_constructor);
-    obj.set_property_by_string_key("prototype".to_string(), vm.object_prototypes.object);
+    let obj = vm
+        .factory
+        .builtin_function("Object".to_string(), object_constructor);
+    obj.set_property_by_string_key("prototype".to_string(), vm.factory.object_prototypes.object);
     obj.get_property_by_str_key("prototype")
         .set_constructor(obj);
     obj
@@ -15,22 +17,14 @@ pub fn object_constructor(
     _cur_frame: &frame::Frame,
 ) -> vm::VMResult {
     if args.len() == 0 {
-        let empty_obj = Value::object(
-            &mut vm.memory_allocator,
-            &vm.object_prototypes,
-            FxHashMap::default(),
-        );
+        let empty_obj = Value::object(&mut vm.factory, FxHashMap::default());
         vm.stack.push(empty_obj.into());
         return Ok(());
     }
 
     match &args[0] {
         Value::Other(NULL) | Value::Other(UNDEFINED) => {
-            let empty_obj = Value::object(
-                &mut vm.memory_allocator,
-                &vm.object_prototypes,
-                FxHashMap::default(),
-            );
+            let empty_obj = Value::object(&mut vm.factory, FxHashMap::default());
             vm.stack.push(empty_obj.into());
         }
         Value::Other(EMPTY) => unreachable!(),

--- a/src/builtins/object.rs
+++ b/src/builtins/object.rs
@@ -17,14 +17,14 @@ pub fn object_constructor(
     _cur_frame: &frame::Frame,
 ) -> vm::VMResult {
     if args.len() == 0 {
-        let empty_obj = Value::object(&mut vm.factory, FxHashMap::default());
+        let empty_obj = vm.factory.object(FxHashMap::default());
         vm.stack.push(empty_obj.into());
         return Ok(());
     }
 
     match &args[0] {
         Value::Other(NULL) | Value::Other(UNDEFINED) => {
-            let empty_obj = Value::object(&mut vm.factory, FxHashMap::default());
+            let empty_obj = vm.factory.object(FxHashMap::default());
             vm.stack.push(empty_obj.into());
         }
         Value::Other(EMPTY) => unreachable!(),

--- a/src/builtins/string.rs
+++ b/src/builtins/string.rs
@@ -19,7 +19,7 @@ pub fn string_prototype_split(
         .split(separator.as_str())
         .collect::<Vec<&str>>()
         .iter()
-        .map(|s| Property::new_data_simple(Value::string(&mut vm.factory, s.to_string())))
+        .map(|s| Property::new_data_simple(vm.factory.string(s.to_string())))
         .collect::<Vec<Property>>();
     let ary = vm.factory.array(elems);
     vm.stack.push(ary.into());

--- a/src/builtins/string.rs
+++ b/src/builtins/string.rs
@@ -1,4 +1,4 @@
-use vm::{error::RuntimeError, frame::Frame, jsvalue::value::*, vm::VM2};
+use vm::{error::RuntimeError, frame::Frame, jsvalue::value::*, vm::VM2, jsvalue::object::Property};
 
 pub fn string_prototype_split(
     vm: &mut VM2,

--- a/src/builtins/string.rs
+++ b/src/builtins/string.rs
@@ -8,11 +8,7 @@ pub fn string_prototype_split(
     let string = cur_frame.this.into_str();
     let separator_ = args.get(0).map(|x| *x).unwrap_or(Value::undefined());
     if separator_.is_undefined() {
-        let ary = Value::array(
-            &mut vm.memory_allocator,
-            &vm.object_prototypes,
-            vec![Property::new_data_simple(cur_frame.this)],
-        );
+        let ary = vm.array(vec![Property::new_data_simple(cur_frame.this)]);
         vm.stack.push(ary.into());
         return Ok(());
     }
@@ -23,7 +19,7 @@ pub fn string_prototype_split(
         .iter()
         .map(|s| Property::new_data_simple(Value::string(&mut vm.memory_allocator, s.to_string())))
         .collect::<Vec<Property>>();
-    let ary = Value::array(&mut vm.memory_allocator, &vm.object_prototypes, elems);
+    let ary = vm.array(elems);
     vm.stack.push(ary.into());
     Ok(())
 }

--- a/src/builtins/string.rs
+++ b/src/builtins/string.rs
@@ -8,7 +8,9 @@ pub fn string_prototype_split(
     let string = cur_frame.this.into_str();
     let separator_ = args.get(0).map(|x| *x).unwrap_or(Value::undefined());
     if separator_.is_undefined() {
-        let ary = vm.array(vec![Property::new_data_simple(cur_frame.this)]);
+        let ary = vm
+            .factory
+            .array(vec![Property::new_data_simple(cur_frame.this)]);
         vm.stack.push(ary.into());
         return Ok(());
     }
@@ -17,9 +19,9 @@ pub fn string_prototype_split(
         .split(separator.as_str())
         .collect::<Vec<&str>>()
         .iter()
-        .map(|s| Property::new_data_simple(Value::string(&mut vm.memory_allocator, s.to_string())))
+        .map(|s| Property::new_data_simple(Value::string(&mut vm.factory, s.to_string())))
         .collect::<Vec<Property>>();
-    let ary = vm.array(elems);
+    let ary = vm.factory.array(elems);
     vm.stack.push(ary.into());
     Ok(())
 }

--- a/src/builtins/symbol.rs
+++ b/src/builtins/symbol.rs
@@ -6,25 +6,28 @@ use vm::{
 };
 
 pub fn symbol(vm: &mut VM2) -> Value {
-    let obj = vm.builtin_function("Symbol".to_string(), symbol_constructor);
+    let obj = vm
+        .factory
+        .builtin_function("Symbol".to_string(), symbol_constructor);
 
     // Symbol.for
     obj.set_property_by_string_key("for".to_string(), {
-        vm.builtin_function("for".to_string(), symbol_for)
+        vm.factory.builtin_function("for".to_string(), symbol_for)
     });
     // Symbol.keyFor
     obj.set_property_by_string_key("keyFor".to_string(), {
-        vm.builtin_function("keyFor".to_string(), symbol_key_for)
+        vm.factory
+            .builtin_function("keyFor".to_string(), symbol_key_for)
     });
 
-    obj.set_property_by_string_key("prototype".to_string(), vm.object_prototypes.symbol);
+    obj.set_property_by_string_key("prototype".to_string(), vm.factory.object_prototypes.symbol);
     obj.get_property_by_str_key("prototype")
         .set_constructor(obj);
     obj
 }
 
 pub fn symbol_constructor(vm: &mut VM2, args: &[Value], _cur_frame: &frame::Frame) -> VMResult {
-    let symbol = vm.symbol(args.get(0).map(|arg| arg.to_string()));
+    let symbol = vm.factory.symbol(args.get(0).map(|arg| arg.to_string()));
     vm.stack.push(symbol.into());
     Ok(())
 }
@@ -45,9 +48,7 @@ pub fn symbol_key_for(vm: &mut VM2, args: &[Value], _cur_frame: &frame::Frame) -
         )));
     }
 
-    let key = vm
-        .global_symbol_registry
-        .key_for(&mut vm.memory_allocator, sym);
+    let key = vm.global_symbol_registry.key_for(&mut vm.factory, sym);
     vm.stack.push(key.into());
     Ok(())
 }

--- a/src/builtins/symbol.rs
+++ b/src/builtins/symbol.rs
@@ -1,4 +1,3 @@
-use gc::MemoryAllocator;
 use vm::{
     error::RuntimeError,
     frame,
@@ -6,58 +5,32 @@ use vm::{
     vm::{VMResult, VM2},
 };
 
-pub fn symbol(
-    memory_allocator: &mut MemoryAllocator,
-    object_prototypes: &ObjectPrototypes,
-) -> Value {
-    let obj = Value::builtin_function(
-        memory_allocator,
-        object_prototypes,
-        "Symbol".to_string(),
-        symbol_constructor,
-    );
+pub fn symbol(vm: &mut VM2) -> Value {
+    let obj = vm.builtin_function("Symbol".to_string(), symbol_constructor);
 
     // Symbol.for
     obj.set_property_by_string_key("for".to_string(), {
-        Value::builtin_function(
-            memory_allocator,
-            object_prototypes,
-            "for".to_string(),
-            symbol_for,
-        )
+        vm.builtin_function("for".to_string(), symbol_for)
     });
     // Symbol.keyFor
     obj.set_property_by_string_key("keyFor".to_string(), {
-        Value::builtin_function(
-            memory_allocator,
-            object_prototypes,
-            "keyFor".to_string(),
-            symbol_key_for,
-        )
+        vm.builtin_function("keyFor".to_string(), symbol_key_for)
     });
 
-    obj.set_property_by_string_key("prototype".to_string(), object_prototypes.symbol);
+    obj.set_property_by_string_key("prototype".to_string(), vm.object_prototypes.symbol);
     obj.get_property_by_str_key("prototype")
         .set_constructor(obj);
     obj
 }
 
 pub fn symbol_constructor(vm: &mut VM2, args: &[Value], _cur_frame: &frame::Frame) -> VMResult {
-    let symbol = Value::symbol(
-        &mut vm.memory_allocator,
-        &vm.object_prototypes,
-        args.get(0).map(|arg| arg.to_string()),
-    );
+    let symbol = vm.symbol(args.get(0).map(|arg| arg.to_string()));
     vm.stack.push(symbol.into());
     Ok(())
 }
 
 pub fn symbol_for(vm: &mut VM2, args: &[Value], _cur_frame: &frame::Frame) -> VMResult {
-    let sym = vm.global_symbol_registry.for_(
-        &mut vm.memory_allocator,
-        &vm.object_prototypes,
-        args.get(0).unwrap_or(&Value::undefined()).to_string(),
-    );
+    let sym = vm.symbol_registory_for_(args.get(0).unwrap_or(&Value::undefined()).to_string());
     vm.stack.push(sym.into());
     Ok(())
 }

--- a/src/bytecode_gen.rs
+++ b/src/bytecode_gen.rs
@@ -124,6 +124,9 @@ impl<'a> ByteCodeGenerator {
     pub fn append_rem(&self, iseq: &mut ByteCode) {
         iseq.push(VMInst::REM);
     }
+    pub fn append_exp(&self, iseq: &mut ByteCode) {
+        iseq.push(VMInst::EXP);
+    }
     pub fn append_lt(&self, iseq: &mut ByteCode) {
         iseq.push(VMInst::LT);
     }
@@ -532,6 +535,7 @@ pub fn show_inst2(code: &ByteCode, i: usize, const_table: &constant::ConstantTab
             }
             VMInst::RETURN_SUB => format!("ReturnSub"),
             VMInst::TYPEOF => format!("Typeof"),
+            VMInst::EXP => format!("Exp"),
             _ => unreachable!("sorry. need to implement more opcodes"),
         }
     );
@@ -610,6 +614,7 @@ pub mod VMInst {
     pub const RETURN_SUB: u8 = 0x44;
     pub const TYPEOF: u8 = 0x45;
     pub const PUSH_NULL: u8 = 0x46;
+    pub const EXP: u8 = 0x47;
 
     pub fn get_inst_size(inst: u8) -> Option<usize> {
         match inst {
@@ -619,7 +624,7 @@ pub mod VMInst {
             | RETURN_TRY | DECL_VAR | LOOP_START | JMP | SET_VALUE | GET_VALUE | CALL | JMP_SUB
             | CALL_METHOD | PUSH_ENV | DECL_LET | DECL_CONST => Some(5),
             PUSH_INT8 => Some(2),
-            PUSH_FALSE | END | PUSH_TRUE | PUSH_THIS | ADD | SUB | MUL | DIV | REM | LT
+            PUSH_FALSE | END | PUSH_TRUE | PUSH_THIS | ADD | SUB | MUL | DIV | REM | LT | EXP
             | PUSH_ARGUMENTS | NEG | POSI | GT | LE | GE | EQ | NE | GET_MEMBER | RETURN | SNE
             | ZFSHR | POP | DOUBLE | AND | COND_OP | OR | SEQ | SET_MEMBER | LNOT
             | UPDATE_PARENT_SCOPE | PUSH_UNDEFINED | LAND | SHR | SHL | XOR | LOR | NOT => Some(1),

--- a/src/main.rs
+++ b/src/main.rs
@@ -133,7 +133,7 @@ fn repl() {
                         Some(ref mut frame) => {
                             frame.bytecode = iseq;
                             frame.exception_table = global_info.exception_table.clone();
-                            frame.append_from_function_info(&mut vm.memory_allocator, &global_info)
+                            frame.append_from_function_info(&mut vm.factory, &global_info)
                         }
                         None => global_frame = Some(vm.create_global_frame(global_info, iseq)),
                     }

--- a/src/vm/codegen.rs
+++ b/src/vm/codegen.rs
@@ -190,7 +190,7 @@ impl<'a> CodeGenerator<'a> {
             NodeBase::String(ref s) => {
                 if use_value {
                     self.bytecode_generator.append_push_const(
-                        Value::string(&mut self.vm.memory_allocator, s.clone()),
+                        Value::string(&mut self.vm.factory, s.clone()),
                         iseq,
                         &mut self.vm.constant_table,
                     )
@@ -634,7 +634,7 @@ impl<'a> CodeGenerator<'a> {
 
         self.to_source_map.insert(id, function_info.to_source_pos);
 
-        Ok(self.vm.function(
+        Ok(self.vm.factory.function(
             function_info.name,
             UserFunctionInfo {
                 id,
@@ -718,7 +718,7 @@ impl<'a> CodeGenerator<'a> {
         }
 
         self.visit(parent, iseq, true)?;
-        let property = Value::string(&mut self.vm.memory_allocator, member.clone());
+        let property = Value::string(&mut self.vm.factory, member.clone());
         self.bytecode_generator
             .append_push_const(property, iseq, &mut self.vm.constant_table);
         self.bytecode_generator.append_get_member(iseq);
@@ -900,7 +900,7 @@ impl<'a> CodeGenerator<'a> {
         match callee.base {
             NodeBase::Member(ref parent, ref property_name) => {
                 self.bytecode_generator.append_push_const(
-                    Value::string(&mut self.vm.memory_allocator, property_name.clone()),
+                    Value::string(&mut self.vm.factory, property_name.clone()),
                     iseq,
                     &mut self.vm.constant_table,
                 );
@@ -967,7 +967,7 @@ impl<'a> CodeGenerator<'a> {
         match callee.base {
             NodeBase::Member(ref parent, ref property_name) => {
                 self.visit(parent, iseq, true)?;
-                let property = Value::string(&mut self.vm.memory_allocator, property_name.clone());
+                let property = Value::string(&mut self.vm.factory, property_name.clone());
                 self.bytecode_generator.append_push_const(
                     property,
                     iseq,
@@ -1006,7 +1006,7 @@ impl<'a> CodeGenerator<'a> {
                         &mut self.vm.constant_table,
                     );
                     self.bytecode_generator.append_push_const(
-                        Value::string(&mut self.vm.memory_allocator, name.clone()),
+                        Value::string(&mut self.vm.factory, name.clone()),
                         iseq,
                         &mut self.vm.constant_table,
                     );
@@ -1014,7 +1014,7 @@ impl<'a> CodeGenerator<'a> {
                 PropertyDefinition::Property(name, node) => {
                     self.visit(&node, iseq, true)?;
                     self.bytecode_generator.append_push_const(
-                        Value::string(&mut self.vm.memory_allocator, name.clone()),
+                        Value::string(&mut self.vm.factory, name.clone()),
                         iseq,
                         &mut self.vm.constant_table,
                     );
@@ -1031,7 +1031,7 @@ impl<'a> CodeGenerator<'a> {
                     };
                     self.visit(&node, iseq, true)?;
                     self.bytecode_generator.append_push_const(
-                        Value::string(&mut self.vm.memory_allocator, name.clone()),
+                        Value::string(&mut self.vm.factory, name.clone()),
                         iseq,
                         &mut self.vm.constant_table,
                     );
@@ -1070,7 +1070,7 @@ impl<'a> CodeGenerator<'a> {
             }
             NodeBase::Member(ref parent, ref property) => {
                 self.visit(&*parent, iseq, true)?;
-                let property = Value::string(&mut self.vm.memory_allocator, property.clone());
+                let property = Value::string(&mut self.vm.factory, property.clone());
                 self.bytecode_generator.append_push_const(
                     property,
                     iseq,

--- a/src/vm/codegen.rs
+++ b/src/vm/codegen.rs
@@ -862,6 +862,7 @@ impl<'a> CodeGenerator<'a> {
             &BinOp::Shl => self.bytecode_generator.append_shl(iseq),
             &BinOp::Shr => self.bytecode_generator.append_shr(iseq),
             &BinOp::ZFShr => self.bytecode_generator.append_zfshr(iseq),
+            &BinOp::Exp => self.bytecode_generator.append_exp(iseq),
             _ => unimplemented!(),
         }
 

--- a/src/vm/codegen.rs
+++ b/src/vm/codegen.rs
@@ -190,7 +190,7 @@ impl<'a> CodeGenerator<'a> {
             NodeBase::String(ref s) => {
                 if use_value {
                     self.bytecode_generator.append_push_const(
-                        Value::string(&mut self.vm.factory, s.clone()),
+                        self.vm.factory.string(s.clone()),
                         iseq,
                         &mut self.vm.constant_table,
                     )
@@ -718,7 +718,7 @@ impl<'a> CodeGenerator<'a> {
         }
 
         self.visit(parent, iseq, true)?;
-        let property = Value::string(&mut self.vm.factory, member.clone());
+        let property = self.vm.factory.string(member.clone());
         self.bytecode_generator
             .append_push_const(property, iseq, &mut self.vm.constant_table);
         self.bytecode_generator.append_get_member(iseq);
@@ -900,7 +900,7 @@ impl<'a> CodeGenerator<'a> {
         match callee.base {
             NodeBase::Member(ref parent, ref property_name) => {
                 self.bytecode_generator.append_push_const(
-                    Value::string(&mut self.vm.factory, property_name.clone()),
+                    self.vm.factory.string(property_name.clone()),
                     iseq,
                     &mut self.vm.constant_table,
                 );
@@ -967,7 +967,7 @@ impl<'a> CodeGenerator<'a> {
         match callee.base {
             NodeBase::Member(ref parent, ref property_name) => {
                 self.visit(parent, iseq, true)?;
-                let property = Value::string(&mut self.vm.factory, property_name.clone());
+                let property = self.vm.factory.string(property_name.clone());
                 self.bytecode_generator.append_push_const(
                     property,
                     iseq,
@@ -1006,7 +1006,7 @@ impl<'a> CodeGenerator<'a> {
                         &mut self.vm.constant_table,
                     );
                     self.bytecode_generator.append_push_const(
-                        Value::string(&mut self.vm.factory, name.clone()),
+                        self.vm.factory.string(name.clone()),
                         iseq,
                         &mut self.vm.constant_table,
                     );
@@ -1014,7 +1014,7 @@ impl<'a> CodeGenerator<'a> {
                 PropertyDefinition::Property(name, node) => {
                     self.visit(&node, iseq, true)?;
                     self.bytecode_generator.append_push_const(
-                        Value::string(&mut self.vm.factory, name.clone()),
+                        self.vm.factory.string(name.clone()),
                         iseq,
                         &mut self.vm.constant_table,
                     );
@@ -1031,7 +1031,7 @@ impl<'a> CodeGenerator<'a> {
                     };
                     self.visit(&node, iseq, true)?;
                     self.bytecode_generator.append_push_const(
-                        Value::string(&mut self.vm.factory, name.clone()),
+                        self.vm.factory.string(name.clone()),
                         iseq,
                         &mut self.vm.constant_table,
                     );
@@ -1070,7 +1070,7 @@ impl<'a> CodeGenerator<'a> {
             }
             NodeBase::Member(ref parent, ref property) => {
                 self.visit(&*parent, iseq, true)?;
-                let property = Value::string(&mut self.vm.factory, property.clone());
+                let property = self.vm.factory.string(property.clone());
                 self.bytecode_generator.append_push_const(
                     property,
                     iseq,

--- a/src/vm/error.rs
+++ b/src/vm/error.rs
@@ -19,11 +19,11 @@ impl RuntimeError {
     pub fn to_value2(self, factory: &mut Factory) -> Value {
         match self {
             RuntimeError::Exception2(v, _) => v,
-            RuntimeError::Type(s) => Value::string(factory, s),
-            RuntimeError::General(s) => Value::string(factory, s),
-            RuntimeError::Reference(s) => Value::string(factory, format!("Reference error: {}", s)),
-            RuntimeError::Unimplemented => Value::string(factory, "Unimplemented".to_string()),
-            RuntimeError::Unknown => Value::string(factory, "Unknown".to_string()),
+            RuntimeError::Type(s) => factory.string(s),
+            RuntimeError::General(s) => factory.string(s),
+            RuntimeError::Reference(s) => factory.string(format!("Reference error: {}", s)),
+            RuntimeError::Unimplemented => factory.string("Unimplemented".to_string()),
+            RuntimeError::Unknown => factory.string("Unknown".to_string()),
         }
     }
 

--- a/src/vm/error.rs
+++ b/src/vm/error.rs
@@ -1,8 +1,8 @@
 use super::super::builtins;
 use crate::lexer;
 use ansi_term::Colour;
+use vm::factory::Factory;
 use vm::jsvalue::value::Value;
-use vm::vm::Factory;
 
 #[derive(Clone, PartialEq, Debug)]
 pub enum RuntimeError {

--- a/src/vm/error.rs
+++ b/src/vm/error.rs
@@ -1,8 +1,8 @@
 use super::super::builtins;
 use crate::lexer;
 use ansi_term::Colour;
-use gc::MemoryAllocator;
 use vm::jsvalue::value::Value;
+use vm::vm::Factory;
 
 #[derive(Clone, PartialEq, Debug)]
 pub enum RuntimeError {
@@ -16,18 +16,14 @@ pub enum RuntimeError {
 
 impl RuntimeError {
     /// convert RuntimeError -> Value
-    pub fn to_value2(self, memory_allocator: &mut MemoryAllocator) -> Value {
+    pub fn to_value2(self, factory: &mut Factory) -> Value {
         match self {
             RuntimeError::Exception2(v, _) => v,
-            RuntimeError::Type(s) => Value::string(memory_allocator, s),
-            RuntimeError::General(s) => Value::string(memory_allocator, s),
-            RuntimeError::Reference(s) => {
-                Value::string(memory_allocator, format!("Reference error: {}", s))
-            }
-            RuntimeError::Unimplemented => {
-                Value::string(memory_allocator, "Unimplemented".to_string())
-            }
-            RuntimeError::Unknown => Value::string(memory_allocator, "Unknown".to_string()),
+            RuntimeError::Type(s) => Value::string(factory, s),
+            RuntimeError::General(s) => Value::string(factory, s),
+            RuntimeError::Reference(s) => Value::string(factory, format!("Reference error: {}", s)),
+            RuntimeError::Unimplemented => Value::string(factory, "Unimplemented".to_string()),
+            RuntimeError::Unknown => Value::string(factory, "Unknown".to_string()),
         }
     }
 

--- a/src/vm/factory.rs
+++ b/src/vm/factory.rs
@@ -1,0 +1,96 @@
+use builtin::BuiltinFuncTy2;
+use gc::MemoryAllocator;
+use rustc_hash::FxHashMap;
+use vm::jsvalue::array::ArrayObjectInfo;
+use vm::jsvalue::function::{FunctionObjectInfo, FunctionObjectKind, UserFunctionInfo};
+use vm::jsvalue::object::{ObjectInfo, ObjectKind2, Property};
+use vm::jsvalue::prototype::ObjectPrototypes;
+use vm::jsvalue::symbol::SymbolInfo;
+use vm::jsvalue::value::Value;
+
+#[derive(Debug)]
+pub struct Factory {
+    pub memory_allocator: MemoryAllocator,
+    pub object_prototypes: ObjectPrototypes,
+}
+
+impl Factory {
+    pub fn string(&mut self, body: String) -> Value {
+        Value::String(
+            self.memory_allocator
+                .alloc(std::ffi::CString::new(body).unwrap()),
+        )
+    }
+
+    pub fn object(&mut self, property: FxHashMap<String, Property>) -> Value {
+        Value::Object(self.memory_allocator.alloc(ObjectInfo {
+            kind: ObjectKind2::Ordinary,
+            prototype: self.object_prototypes.object,
+            property,
+            sym_property: FxHashMap::default(),
+        }))
+    }
+
+    pub fn function(&mut self, name: Option<String>, info: UserFunctionInfo) -> Value {
+        let name_prop = self.string(name.clone().unwrap_or("".to_string()));
+        let prototype = self.object(FxHashMap::default());
+
+        let f = Value::Object(self.memory_allocator.alloc(ObjectInfo {
+            prototype: self.object_prototypes.function,
+            property: make_property_map!(
+                length    => false, false, true : Value::Number(info.params.len() as f64), /* TODO: rest param */
+                name      => false, false, true : name_prop,
+                prototype => true , false, false: prototype
+            ),
+            kind: ObjectKind2::Function(FunctionObjectInfo {
+                name: name,
+                kind: FunctionObjectKind::User(info)
+            }),
+            sym_property: FxHashMap::default(),
+        }));
+
+        f.get_property_by_str_key("prototype")
+            .get_object_info()
+            .property
+            .insert("constructor".to_string(), Property::new_data_simple(f));
+
+        f
+    }
+
+    pub fn builtin_function(&mut self, name: String, func: BuiltinFuncTy2) -> Value {
+        let name_prop = self.string(name.clone());
+        Value::Object(self.memory_allocator.alloc(ObjectInfo {
+            kind: ObjectKind2::Function(FunctionObjectInfo {
+                name: Some(name),
+                kind: FunctionObjectKind::Builtin(func),
+            }),
+            prototype: self.object_prototypes.function,
+            property: make_property_map!(
+                length => false, false, true : Value::Number(0.0),
+                name   => false, false, true : name_prop
+            ),
+            sym_property: FxHashMap::default(),
+        }))
+    }
+
+    pub fn array(&mut self, elems: Vec<Property>) -> Value {
+        Value::Object(self.memory_allocator.alloc(ObjectInfo {
+            kind: ObjectKind2::Array(ArrayObjectInfo { elems }),
+            prototype: self.object_prototypes.array,
+            property: make_property_map!(),
+            sym_property: FxHashMap::default(),
+        }))
+    }
+
+    pub fn symbol(&mut self, description: Option<String>) -> Value {
+        Value::Object(self.memory_allocator.alloc(ObjectInfo {
+            kind: ObjectKind2::Symbol(SymbolInfo {
+                id: ::id::get_unique_id(),
+                description,
+            }),
+            prototype: self.object_prototypes.symbol,
+            property: make_property_map!(),
+            sym_property: FxHashMap::default(),
+        }))
+    }
+}

--- a/src/vm/frame.rs
+++ b/src/vm/frame.rs
@@ -6,11 +6,12 @@ use rustc_hash::FxHashMap;
 use std::ops::{Deref, DerefMut};
 use vm::codegen::FunctionInfo;
 use vm::error::RuntimeError;
+use vm::factory::Factory;
 use vm::jsvalue::function::Exception;
 use vm::jsvalue::object::{ObjectInfo, ObjectKind2};
 use vm::jsvalue::prototype::ObjectPrototypes;
 use vm::jsvalue::value::Value;
-use vm::vm::{Factory, VMResult};
+use vm::vm::VMResult;
 
 #[derive(Debug, Clone, Copy)]
 pub struct LexicalEnvironmentRef(pub *mut LexicalEnvironment);

--- a/src/vm/frame.rs
+++ b/src/vm/frame.rs
@@ -232,7 +232,7 @@ impl LexicalEnvironment {
             }
         };
 
-        if let Some(outer) = self.get_outer() {
+        if let Some(outer) = self.outer {
             outer.get_value(name)
         } else {
             Err(RuntimeError::Reference(format!(
@@ -258,7 +258,7 @@ impl LexicalEnvironment {
             }
         };
 
-        if let Some(outer) = self.get_outer() {
+        if let Some(mut outer) = self.outer {
             outer.set_value(name, val)
         } else {
             Err(RuntimeError::Reference(format!(
@@ -279,11 +279,6 @@ impl LexicalEnvironment {
             }
         };
         return Ok(());
-    }
-
-    pub fn get_outer(&self) -> Option<&mut LexicalEnvironment> {
-        self.outer
-            .and_then(|outer| Some(unsafe { &mut *outer.as_ptr() }))
     }
 
     pub fn get_global_object(&self) -> Value {

--- a/src/vm/jsvalue/array.rs
+++ b/src/vm/jsvalue/array.rs
@@ -1,7 +1,5 @@
-// use super::super::frame::LexicalEnvironmentRef;
 use super::value::*;
-// use builtin::BuiltinFuncTy2;
-// use bytecode_gen::ByteCode;
+use vm::jsvalue::object::Property;
 
 #[derive(Clone, Debug)]
 pub struct ArrayObjectInfo {

--- a/src/vm/jsvalue/object.rs
+++ b/src/vm/jsvalue/object.rs
@@ -1,7 +1,7 @@
 use super::super::error;
 use super::value::*;
 pub use rustc_hash::FxHashMap;
-use vm::vm::Factory;
+use vm::factory::Factory;
 
 #[derive(Clone, Debug)]
 pub struct ObjectInfo {
@@ -57,7 +57,7 @@ impl ObjectInfo {
 
     pub fn get_property(
         &self,
-        factory: &mut ::vm::vm::Factory,
+        factory: &mut Factory,
         key: Value,
     ) -> Result<Property, error::RuntimeError> {
         // Annoying

--- a/src/vm/jsvalue/object.rs
+++ b/src/vm/jsvalue/object.rs
@@ -1,8 +1,7 @@
-use super::super::super::gc::MemoryAllocator;
 use super::super::error;
-use super::prototype::ObjectPrototypes;
 use super::value::*;
 pub use rustc_hash::FxHashMap;
+use vm::vm::Factory;
 
 #[derive(Clone, Debug)]
 pub struct ObjectInfo {
@@ -58,8 +57,7 @@ impl ObjectInfo {
 
     pub fn get_property(
         &self,
-        allocator: &mut MemoryAllocator,
-        object_prototypes: &ObjectPrototypes,
+        factory: &mut ::vm::vm::Factory,
         key: Value,
     ) -> Result<Property, error::RuntimeError> {
         // Annoying
@@ -71,9 +69,7 @@ impl ObjectInfo {
             let id = key.get_symbol_info().id;
             return match self.sym_property.get(&id) {
                 Some(prop) => Ok(*prop),
-                None => self
-                    .prototype
-                    .get_property(allocator, object_prototypes, key),
+                None => self.prototype.get_property(factory, key),
             };
         }
 
@@ -83,7 +79,7 @@ impl ObjectInfo {
                     return Ok(info.get_element(idx));
                 }
 
-                if let Some(idx) = key.is_canonical_numeric_index_string(allocator) {
+                if let Some(idx) = key.is_canonical_numeric_index_string(factory) {
                     return Ok(info.get_element(idx));
                 }
 
@@ -98,9 +94,7 @@ impl ObjectInfo {
 
         match self.property.get(key.to_string().as_str()) {
             Some(prop) => Ok(*prop),
-            None => self
-                .prototype
-                .get_property(allocator, object_prototypes, key),
+            None => self.prototype.get_property(factory, key),
         }
     }
 
@@ -124,7 +118,7 @@ impl ObjectInfo {
 
     pub fn set_property(
         &mut self,
-        allocator: &mut MemoryAllocator,
+        factory: &mut Factory,
         key: Value,
         val_: Value,
     ) -> Result<Option<Value>, error::RuntimeError> {
@@ -140,7 +134,7 @@ impl ObjectInfo {
                     return Ok(info.set_element(idx, val_));
                 }
 
-                if let Some(idx) = key.is_canonical_numeric_index_string(allocator) {
+                if let Some(idx) = key.is_canonical_numeric_index_string(factory) {
                     return Ok(info.set_element(idx, val_));
                 }
 

--- a/src/vm/jsvalue/symbol.rs
+++ b/src/vm/jsvalue/symbol.rs
@@ -27,7 +27,7 @@ impl GlobalSymbolRegistry {
 
     pub fn key_for(&mut self, factory: &mut ::vm::vm::Factory, sym: Value) -> Value {
         if let Some((key, _)) = self.list.iter().find(|(_, sym_)| sym == *sym_) {
-            return Value::string(factory, key.to_owned());
+            return factory.string(key.to_owned());
         }
 
         Value::undefined()

--- a/src/vm/jsvalue/symbol.rs
+++ b/src/vm/jsvalue/symbol.rs
@@ -1,4 +1,4 @@
-use super::{super::super::gc::MemoryAllocator, value::Value};
+use super::value::Value;
 
 #[derive(Debug, Clone)]
 pub struct SymbolInfo {
@@ -25,9 +25,9 @@ impl GlobalSymbolRegistry {
         Self { list: vec![] }
     }
 
-    pub fn key_for(&mut self, allocator: &mut MemoryAllocator, sym: Value) -> Value {
+    pub fn key_for(&mut self, factory: &mut ::vm::vm::Factory, sym: Value) -> Value {
         if let Some((key, _)) = self.list.iter().find(|(_, sym_)| sym == *sym_) {
-            return Value::string(allocator, key.to_owned());
+            return Value::string(factory, key.to_owned());
         }
 
         Value::undefined()

--- a/src/vm/jsvalue/symbol.rs
+++ b/src/vm/jsvalue/symbol.rs
@@ -1,4 +1,5 @@
 use super::value::Value;
+use vm::factory::Factory;
 
 #[derive(Debug, Clone)]
 pub struct SymbolInfo {
@@ -25,7 +26,7 @@ impl GlobalSymbolRegistry {
         Self { list: vec![] }
     }
 
-    pub fn key_for(&mut self, factory: &mut ::vm::vm::Factory, sym: Value) -> Value {
+    pub fn key_for(&mut self, factory: &mut Factory, sym: Value) -> Value {
         if let Some((key, _)) = self.list.iter().find(|(_, sym_)| sym == *sym_) {
             return factory.string(key.to_owned());
         }

--- a/src/vm/jsvalue/symbol.rs
+++ b/src/vm/jsvalue/symbol.rs
@@ -1,4 +1,4 @@
-use super::{super::super::gc::MemoryAllocator, prototype::ObjectPrototypes, value::Value};
+use super::{super::super::gc::MemoryAllocator, value::Value};
 
 #[derive(Debug, Clone)]
 pub struct SymbolInfo {
@@ -17,28 +17,12 @@ impl SymbolInfo {
 
 #[derive(Debug, Clone)]
 pub struct GlobalSymbolRegistry {
-    list: Vec<(String, Value)>,
+    pub list: Vec<(String, Value)>,
 }
 
 impl GlobalSymbolRegistry {
     pub fn new() -> Self {
         Self { list: vec![] }
-    }
-
-    pub fn for_(
-        &mut self,
-        allocator: &mut MemoryAllocator,
-        object_prototypes: &ObjectPrototypes,
-        key: String,
-    ) -> Value {
-        if let Some((_, sym)) = self.list.iter().find(|(key_, _)| key == *key_) {
-            return *sym;
-        }
-
-        let sym = Value::symbol(allocator, object_prototypes, Some(key.clone()));
-        self.list.push((key, sym));
-
-        sym
     }
 
     pub fn key_for(&mut self, allocator: &mut MemoryAllocator, sym: Value) -> Value {

--- a/src/vm/jsvalue/value.rs
+++ b/src/vm/jsvalue/value.rs
@@ -9,7 +9,8 @@ use builtin::BuiltinFuncTy2;
 use gc::MemoryAllocator;
 pub use rustc_hash::FxHashMap;
 use std::ffi::CString;
-use vm::vm::Factory;
+use vm::factory::Factory;
+use vm::jsvalue::object::Property;
 
 pub const UNINITIALIZED: i32 = 0;
 pub const EMPTY: i32 = 1;
@@ -46,7 +47,7 @@ macro_rules! add_property_sub {
     ),*) => { {
         $( $objectinfo.property.insert(
             (stringify!($property_name)).to_string(),
-            Property::Data(DataProperty {
+            ::vm::jsvalue::object::Property::Data(::vm::jsvalue::object::DataProperty {
                 val: $val,
                 writable: $writable,
                 enumerable: $enumerable,
@@ -76,7 +77,7 @@ macro_rules! make_property_map_sub {
         let mut record = FxHashMap::default();
         $( record.insert(
             (stringify!($property_name)).to_string(),
-            Property::Data(DataProperty {
+            ::vm::jsvalue::object::Property::Data(::vm::jsvalue::object::DataProperty {
                 val: $val,
                 writable: $writable,
                 enumerable: $enumerable,
@@ -283,11 +284,11 @@ impl Value {
 
     pub fn get_property(
         &self,
-        factory: &mut ::vm::vm::Factory,
+        factory: &mut Factory,
         key: Value,
     ) -> Result<Property, error::RuntimeError> {
         fn string_get_property(
-            factory: &mut ::vm::vm::Factory,
+            factory: &mut Factory,
             s: &str,
             key: Value,
         ) -> Result<Property, error::RuntimeError> {
@@ -334,7 +335,7 @@ impl Value {
 
     pub fn set_property(
         &self,
-        factory: &mut ::vm::vm::Factory,
+        factory: &mut Factory,
         key: Value,
         val: Value,
     ) -> Result<Option<Value>, error::RuntimeError> {

--- a/src/vm/jsvalue/value.rs
+++ b/src/vm/jsvalue/value.rs
@@ -8,6 +8,7 @@ pub use super::symbol::*;
 use builtin::BuiltinFuncTy2;
 use gc::MemoryAllocator;
 pub use rustc_hash::FxHashMap;
+use std::f64::NAN;
 use std::ffi::CString;
 use vm::factory::Factory;
 use vm::jsvalue::object::Property;
@@ -632,29 +633,33 @@ impl Value {
     pub fn sub(self, val: Value) -> Self {
         match (self, val) {
             (Value::Number(x), Value::Number(y)) => Value::Number(x - y),
-            _ => Value::undefined(),
+            _ => Value::Number(NAN),
         }
     }
 
     pub fn mul(self, val: Value) -> Self {
         match (self, val) {
             (Value::Number(x), Value::Number(y)) => Value::Number(x * y),
-            _ => Value::undefined(),
+            _ => Value::Number(NAN),
         }
     }
 
     pub fn div(self, val: Value) -> Self {
         match (self, val) {
             (Value::Number(x), Value::Number(y)) => Value::Number(x / y),
-            _ => Value::undefined(),
+            _ => Value::Number(NAN),
         }
     }
 
     pub fn rem(self, val: Value) -> Self {
         match (self, val) {
             (Value::Number(x), Value::Number(y)) => Value::Number((x as i64 % y as i64) as f64),
-            _ => Value::undefined(),
+            _ => Value::Number(NAN),
         }
+    }
+
+    pub fn exp(self, factory: &mut Factory, val: Value) -> Self {
+        Value::Number(self.to_number(factory).powf(val.to_number(factory)))
     }
 
     pub fn and(self, factory: &mut Factory, val: Value) -> Self {

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -3,5 +3,6 @@ pub mod jsvalue;
 pub mod codegen;
 pub mod constant;
 pub mod error;
+pub mod factory;
 pub mod frame;
 pub mod vm;

--- a/src/vm/vm.rs
+++ b/src/vm/vm.rs
@@ -427,6 +427,12 @@ impl VM2 {
                     let lhs: Value = self.stack.pop().unwrap().into();
                     self.stack.push(lhs.rem(rhs).into());
                 }
+                VMInst::EXP => {
+                    cur_frame.pc += 1;
+                    let rhs: Value = self.stack.pop().unwrap().into();
+                    let lhs: Value = self.stack.pop().unwrap().into();
+                    self.stack.push(lhs.exp(&mut self.factory, rhs).into());
+                }
                 VMInst::EQ => {
                     cur_frame.pc += 1;
                     let rhs: Value = self.stack.pop().unwrap().into();

--- a/src/vm/vm.rs
+++ b/src/vm/vm.rs
@@ -889,20 +889,7 @@ impl VM2 {
             sym_property: FxHashMap::default(),
         }));
 
-        if !callee.is_function_object() {
-            return Err(RuntimeError::Type("Not a function".to_string()));
-        }
-
-        let info = callee.as_function();
-
-        match info.kind {
-            FunctionObjectKind::Builtin(func) => {
-                func(self, args, &frame::Frame::new_empty_with_this(this, true))
-            }
-            FunctionObjectKind::User(ref user_func) => {
-                self.enter_user_function(user_func, args, this, cur_frame, true)
-            }
-        }
+        self.enter_function(callee, args, this, cur_frame, true)
     }
 
     fn enter_function(
@@ -923,7 +910,11 @@ impl VM2 {
             FunctionObjectKind::Builtin(func) => gc_lock!(
                 self,
                 args,
-                func(self, args, &frame::Frame::new_empty_with_this(this, false))
+                func(
+                    self,
+                    args,
+                    &frame::Frame::new_empty_with_this(this, constructor_call)
+                )
             ),
             FunctionObjectKind::User(ref user_func) => {
                 self.enter_user_function(user_func, args, this, cur_frame, constructor_call)


### PR DESCRIPTION
This PR is a proposal of refactoring.

1. Add some utility methods for creating variable / lexical environment, and preparing a new frame (execution context) for JS function invocation.
2. Separate `memory_allocator` and `object_prototypes` member as a `Factory` struct from `VM2`.
3. Move some methods for generating objects or arrays etc from `Value` to `Factory`.

```Rust
    // current
    let obj = Value::builtin_function(
        memory_allocator,
        object_prototypes,
        "Foo".to_string(),
        some_method,
    );
    // this PR
    let obj = factory
        .builtin_function("Foo".to_string(), some_method);
```
4. Essentially unchanged in functionality.
5. `cargo test` passed.

Sorry for many lines of addition and deletions in one PR...

Thanks for your consideration!