### PR TITLE
improve runtime error handling, add error.

### DIFF
--- a/src/bytecode_gen.rs
+++ b/src/bytecode_gen.rs
@@ -380,7 +380,7 @@ pub fn show2(code: &ByteCode, const_table: &constant::ConstantTable) {
 
 pub fn show_inst2(code: &ByteCode, i: usize, const_table: &constant::ConstantTable) {
     print!(
-        "{:04x} {:<25}",
+        "{:05} {:<25}",
         i,
         match code[i] {
             VMInst::END => format!("End"),

--- a/src/main.rs
+++ b/src/main.rs
@@ -67,7 +67,7 @@ fn main() {
     let node = match parser.parse_all() {
         Ok(ok) => ok,
         Err(err) => {
-            parser.handle_error(err);
+            parser.handle_error(&err);
             return;
         }
     };
@@ -85,6 +85,7 @@ fn main() {
 
     println!("CodeGenerator generated:");
     bytecode_gen::show2(&iseq, &vm.constant_table);
+    println!("{:?}", vm.to_source_map);
 
     println!("Result:");
     if let Err(e) = vm.run_global(global_info, iseq) {
@@ -139,7 +140,7 @@ fn repl() {
                     }
 
                     if let Err(e) = vm.run(global_frame.clone().unwrap()) {
-                        e.show_error_message(None);
+                        e.show_error_message(Some(&parser.lexer));
                         break;
                     }
 
@@ -161,7 +162,7 @@ fn repl() {
                     Err(_) => break,
                 },
                 Err(e) => {
-                    parser.handle_error(e);
+                    parser.handle_error(&e);
                     break;
                 }
             }
@@ -171,7 +172,7 @@ fn repl() {
 
 #[cfg(test)]
 mod tests {
-    use rapidus::test::{assert_file, execute_script, test_code, test_file};
+    use rapidus::test::{assert_file, execute_script, runtime_error, test_code, test_file};
 
     #[test]
     fn vm_test() {
@@ -321,5 +322,30 @@ mod tests {
     #[test]
     fn assert() {
         assert_file("assert")
+    }
+
+    #[test]
+    fn runtime_error1() {
+        runtime_error("let a = {}; a.b.c");
+    }
+
+    #[test]
+    fn runtime_error2() {
+        runtime_error("let a = {}; a.b.c = 5");
+    }
+
+    #[test]
+    fn runtime_error3() {
+        runtime_error("let a = {}; a(5)");
+    }
+
+    #[test]
+    fn runtime_error4() {
+        runtime_error("let a = {}; a.b(5)");
+    }
+
+    #[test]
+    fn runtime_error5() {
+        runtime_error("let a = {}; a(5)");
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -62,20 +62,20 @@ impl Parser {
     }
 
     /// display syntax error message.
-    pub fn handle_error(&self, err: Error) {
+    pub fn handle_error(&self, err: &Error) {
         match err {
             Error::NormalEOF => unreachable!(),
             Error::Expect(pos, msg)
             | Error::General(pos, msg)
             | Error::UnexpectedToken(pos, msg) => {
-                self.show_error_at(pos, msg.as_str());
+                self.show_error_at(*pos, msg.as_str());
             }
             Error::UnexpectedEOF(msg) => {
                 self.show_error_at(self.lexer.pos, format!("unexpected EOF. {}", msg).as_str())
             }
-            Error::InvalidToken(pos) => self.show_error_at(pos, "Invalid token."),
+            Error::InvalidToken(pos) => self.show_error_at(*pos, "Invalid token."),
             Error::UnsupportedFeature(pos) => {
-                self.show_error_at(pos, "Unsupported feature.");
+                self.show_error_at(*pos, "Unsupported feature.");
             }
         }
     }

--- a/src/test.rs
+++ b/src/test.rs
@@ -44,6 +44,23 @@ pub fn test_code(code: String, answer: String) {
     compare_scripts(code, answer);
 }
 
+/// Execute the given code, and normally terminates only when an runtime error is returned.
+/// ### Panic
+/// Panic if the code returned a parse error, or terminated without error.
+pub fn runtime_error(text: &str) -> String {
+    let mut vm = vm::vm::VM2::new();
+
+    let mut parser = parser::Parser::new(text.to_string());
+    let node = parser.parse_all().unwrap();
+    let mut iseq = vec![];
+
+    let func_info = vm.compile(&node, &mut iseq, true).unwrap();
+    match vm.run_global(func_info, iseq) {
+        Ok(()) => panic!(),
+        Err(err) => return format!("{:?}", err),
+    };
+}
+
 /// Execute the given code.
 /// ### Panic
 /// Panic if the given code returned Err.

--- a/src/vm/jsvalue/object.rs
+++ b/src/vm/jsvalue/object.rs
@@ -98,9 +98,13 @@ impl ObjectInfo {
 
         match self.property.get(key.to_string().as_str()) {
             Some(prop) => Ok(*prop),
-            None => self
-                .prototype
-                .get_property(allocator, object_prototypes, key),
+            None => {
+                let proto = self.prototype;
+                if proto.is_null() {
+                    return Ok(Property::new_data_simple(Value::undefined()));
+                };
+                proto.get_property(allocator, object_prototypes, key)
+            }
         }
     }
 

--- a/src/vm/jsvalue/value.rs
+++ b/src/vm/jsvalue/value.rs
@@ -251,6 +251,13 @@ impl Value {
         }
     }
 
+    pub fn is_null(&self) -> bool {
+        match self {
+            Value::Other(NULL) => true,
+            _ => false,
+        }
+    }
+
     pub fn is_object(&self) -> bool {
         match self {
             Value::Object(_) => true,
@@ -399,6 +406,13 @@ impl Value {
                     key,
                 );
             }
+            Value::Other(_) => {
+                return Err(error::RuntimeError::Type(format!(
+                    "TypeError: Cannot read property '{}' of {}",
+                    key.to_string(),
+                    self.to_string()
+                )));
+            }
             // TODO: Number
             _ => {}
         }
@@ -428,6 +442,11 @@ impl Value {
     ) -> Result<Option<Value>, error::RuntimeError> {
         match self {
             Value::Object(obj_info) => unsafe { &mut **obj_info }.set_property(allocator, key, val),
+            Value::Other(_) => Err(error::RuntimeError::Type(format!(
+                "TypeError: Cannot set property '{}' of {}",
+                key.to_string(),
+                self.to_string()
+            ))),
             _ => Ok(None),
         }
     }
@@ -578,6 +597,7 @@ impl Value {
             Value::Bool(1) => "true".to_string(),
             Value::String(s) => unsafe { &**s }.to_str().unwrap().to_string(),
             Value::Other(UNDEFINED) => "undefined".to_string(),
+            Value::Other(NULL) => "null".to_string(),
             Value::Number(n) => {
                 if n.is_nan() {
                     "NaN".to_string()


### PR DESCRIPTION
This PR improves runtime error handling, and adds tests.

1. Cover all bytecode instructions possibly raise runtime errors. (`THROW`, `GET_MEMBER`, `SET_MEMBER`, `GET_VALUE`, `SET_VALUE`, `CALL`, `CALL_METHOD`)

2. Fix the bug that VM returned `undefined` instead of raising TypeError, when the program tried to read or set a property of `undefined` or `null`.

```javascript
let a = {}
let x = a.b    // undefined
let y = a.b.c  // should raise TypeError, but returns undefined.
```

3. Fix the behavior that CodeGen did not generate bytecodes for expressions  in some situation.  This behavior may hide the errors that should occur.

```javascript
a          // no error, should be a ReferenceError
let b = a  // runtime error 
```