### PR TITLE
Refactor

### DIFF
--- a/src/builtin.rs
+++ b/src/builtin.rs
@@ -116,6 +116,6 @@ pub fn require(vm: &mut VM, args: &[Value], _cur_frame: &Frame) -> Result<(), Ru
         RuntimeError::General(format!("Error in parsing module \"{}\"", file_name))
     }));
     vm.stack
-        .push(Value::string(&mut vm.memory_allocator, script).into());
+        .push(Value::string(&mut vm.factory.memory_allocator, script).into());
     Ok(())
 }

--- a/src/builtin.rs
+++ b/src/builtin.rs
@@ -115,7 +115,6 @@ pub fn require(vm: &mut VM, args: &[Value], _cur_frame: &Frame) -> Result<(), Ru
         parser.show_error_at(token_pos, msg.as_str());
         RuntimeError::General(format!("Error in parsing module \"{}\"", file_name))
     }));
-    vm.stack
-        .push(Value::string(&mut vm.factory.memory_allocator, script).into());
+    vm.stack.push(vm.factory.string(script).into());
     Ok(())
 }

--- a/src/builtins/array.rs
+++ b/src/builtins/array.rs
@@ -63,14 +63,7 @@ pub fn array_prototype_map(vm: &mut VM, args: &[Value], cur_frame: &Frame) -> VM
         ));
     }
 
-    vm.stack.push(
-        Value::array(
-            &mut vm.factory.memory_allocator,
-            &vm.factory.object_prototypes,
-            new_ary,
-        )
-        .into(),
-    );
+    vm.stack.push(vm.factory.array(new_ary).into());
 
     Ok(())
 }

--- a/src/builtins/array.rs
+++ b/src/builtins/array.rs
@@ -6,8 +6,8 @@ use crate::vm::{
 };
 
 pub fn array(factory: &mut Factory) -> Value {
-    let ary = factory.builtin_function("Array".to_string(), array_constructor);
-    ary.set_property_by_string_key("prototype".to_string(), factory.object_prototypes.array);
+    let ary = factory.builtin_function("Array", array_constructor);
+    ary.set_property_by_string_key("prototype", factory.object_prototypes.array);
     ary.get_property_by_str_key("prototype")
         .set_constructor(ary);
     ary

--- a/src/builtins/array.rs
+++ b/src/builtins/array.rs
@@ -1,22 +1,13 @@
-use crate::gc;
 use crate::vm::{
     error::RuntimeError,
     frame::Frame,
-    jsvalue::{object::Property, prototype::ObjectPrototypes, value::Value},
-    vm::{VMResult, VM},
+    jsvalue::{object::Property, value::Value},
+    vm::{Factory, VMResult, VM},
 };
 
-pub fn array(
-    memory_allocator: &mut gc::MemoryAllocator,
-    object_prototypes: &ObjectPrototypes,
-) -> Value {
-    let ary = Value::builtin_function(
-        memory_allocator,
-        object_prototypes,
-        "Array".to_string(),
-        array_constructor,
-    );
-    ary.set_property_by_string_key("prototype".to_string(), object_prototypes.array);
+pub fn array(factory: &mut Factory) -> Value {
+    let ary = factory.builtin_function("Array".to_string(), array_constructor);
+    ary.set_property_by_string_key("prototype".to_string(), factory.object_prototypes.array);
     ary.get_property_by_str_key("prototype")
         .set_constructor(ary);
     ary

--- a/src/builtins/array.rs
+++ b/src/builtins/array.rs
@@ -72,8 +72,14 @@ pub fn array_prototype_map(vm: &mut VM, args: &[Value], cur_frame: &Frame) -> VM
         ));
     }
 
-    vm.stack
-        .push(Value::array(&mut vm.memory_allocator, &vm.object_prototypes, new_ary).into());
+    vm.stack.push(
+        Value::array(
+            &mut vm.factory.memory_allocator,
+            &vm.factory.object_prototypes,
+            new_ary,
+        )
+        .into(),
+    );
 
     Ok(())
 }

--- a/src/builtins/function.rs
+++ b/src/builtins/function.rs
@@ -5,8 +5,8 @@ use crate::vm::{
 };
 
 pub fn function(factory: &mut Factory) -> Value {
-    let func = factory.builtin_function("Function".to_string(), function_constructor);
-    func.set_property_by_string_key("prototype".to_string(), factory.object_prototypes.function);
+    let func = factory.builtin_function("Function", function_constructor);
+    func.set_property_by_string_key("prototype", factory.object_prototypes.function);
     func.get_property_by_str_key("prototype")
         .set_constructor(func);
     func

--- a/src/builtins/function.rs
+++ b/src/builtins/function.rs
@@ -1,36 +1,23 @@
-use crate::gc;
-use crate::vm::{frame, jsvalue, jsvalue::value::Value, vm};
+use crate::vm::{
+    frame,
+    jsvalue::value::Value,
+    vm::{Factory, VMResult, VM},
+};
 
-pub fn function(
-    memory_allocator: &mut gc::MemoryAllocator,
-    object_prototypes: &jsvalue::prototype::ObjectPrototypes,
-) -> Value {
-    let func = Value::builtin_function(
-        memory_allocator,
-        object_prototypes,
-        "Function".to_string(),
-        function_constructor,
-    );
-    func.set_property_by_string_key("prototype".to_string(), object_prototypes.function);
+pub fn function(factory: &mut Factory) -> Value {
+    let func = factory.builtin_function("Function".to_string(), function_constructor);
+    func.set_property_by_string_key("prototype".to_string(), factory.object_prototypes.function);
     func.get_property_by_str_key("prototype")
         .set_constructor(func);
     func
 }
 
-pub fn function_constructor(
-    vm: &mut vm::VM,
-    _args: &[Value],
-    _cur_frame: &frame::Frame,
-) -> vm::VMResult {
+pub fn function_constructor(vm: &mut VM, _args: &[Value], _cur_frame: &frame::Frame) -> VMResult {
     vm.stack.push(Value::undefined().into());
     Ok(())
 }
 
-pub fn function_prototype_call(
-    vm: &mut vm::VM,
-    args: &[Value],
-    cur_frame: &frame::Frame,
-) -> vm::VMResult {
+pub fn function_prototype_call(vm: &mut VM, args: &[Value], cur_frame: &frame::Frame) -> VMResult {
     let this_arg = *args.get(0).unwrap_or(&Value::undefined());
     let func = cur_frame.this;
     vm.call_function(func, args.get(1..).unwrap_or(&[]), this_arg, cur_frame)

--- a/src/builtins/math.rs
+++ b/src/builtins/math.rs
@@ -1,30 +1,23 @@
-use crate::gc::MemoryAllocator;
 use crate::vm::{
     frame,
-    jsvalue::prototype::ObjectPrototypes,
     jsvalue::{
         object::{DataProperty, ObjectInfo, ObjectKind, Property},
         value::Value,
     },
-    vm,
+    vm::{Factory, VMResult, VM},
 };
 use rand::random;
 use rustc_hash::FxHashMap;
 
-pub fn math(memory_allocator: &mut MemoryAllocator, object_prototypes: &ObjectPrototypes) -> Value {
-    let math_random = Value::builtin_function(
-        memory_allocator,
-        object_prototypes,
-        "random".to_string(),
-        math_random,
-    );
+pub fn math(factory: &mut Factory) -> Value {
+    let math_random = factory.builtin_function("random".to_string(), math_random);
 
-    make_normal_object!(memory_allocator, object_prototypes,
+    make_normal_object!(factory,
         random => true, false, true: math_random
     )
 }
 
-pub fn math_random(vm: &mut vm::VM, _args: &[Value], _cur_frame: &frame::Frame) -> vm::VMResult {
+pub fn math_random(vm: &mut VM, _args: &[Value], _cur_frame: &frame::Frame) -> VMResult {
     vm.stack.push(Value::Number(random::<f64>()).into());
     Ok(())
 }

--- a/src/builtins/math.rs
+++ b/src/builtins/math.rs
@@ -10,7 +10,7 @@ use rand::random;
 use rustc_hash::FxHashMap;
 
 pub fn math(factory: &mut Factory) -> Value {
-    let math_random = factory.builtin_function("random".to_string(), math_random);
+    let math_random = factory.builtin_function("random", math_random);
 
     make_normal_object!(factory,
         random => true, false, true: math_random

--- a/src/builtins/object.rs
+++ b/src/builtins/object.rs
@@ -1,45 +1,28 @@
-use crate::gc;
-use crate::vm::{frame, jsvalue::value::*, vm};
+use crate::vm::{
+    frame,
+    jsvalue::value::*,
+    vm::{Factory, VMResult, VM},
+};
 use rustc_hash::FxHashMap;
 
-pub fn object(
-    memory_allocator: &mut gc::MemoryAllocator,
-    object_prototypes: &ObjectPrototypes,
-) -> Value {
-    let obj = Value::builtin_function(
-        memory_allocator,
-        object_prototypes,
-        "Object".to_string(),
-        object_constructor,
-    );
-    obj.set_property_by_string_key("prototype", object_prototypes.object);
+pub fn object(factory: &mut Factory) -> Value {
+    let obj = factory.builtin_function("Object", object_constructor);
+    obj.set_property_by_string_key("prototype", factory.object_prototypes.object);
     obj.get_property_by_str_key("prototype")
         .set_constructor(obj);
     obj
 }
 
-pub fn object_constructor(
-    vm: &mut vm::VM,
-    args: &[Value],
-    _cur_frame: &frame::Frame,
-) -> vm::VMResult {
+pub fn object_constructor(vm: &mut VM, args: &[Value], _cur_frame: &frame::Frame) -> VMResult {
     if args.len() == 0 {
-        let empty_obj = Value::object(
-            &mut vm.factory.memory_allocator,
-            &vm.factory.object_prototypes,
-            FxHashMap::default(),
-        );
+        let empty_obj = vm.factory.object(FxHashMap::default());
         vm.stack.push(empty_obj.into());
         return Ok(());
     }
 
     match &args[0] {
         Value::Other(NULL) | Value::Other(UNDEFINED) => {
-            let empty_obj = Value::object(
-                &mut vm.factory.memory_allocator,
-                &vm.factory.object_prototypes,
-                FxHashMap::default(),
-            );
+            let empty_obj = vm.factory.object(FxHashMap::default());
             vm.stack.push(empty_obj.into());
         }
         Value::Other(EMPTY) => unreachable!(),

--- a/src/builtins/object.rs
+++ b/src/builtins/object.rs
@@ -12,7 +12,7 @@ pub fn object(
         "Object".to_string(),
         object_constructor,
     );
-    obj.set_property_by_string_key("prototype".to_string(), object_prototypes.object);
+    obj.set_property_by_string_key("prototype", object_prototypes.object);
     obj.get_property_by_str_key("prototype")
         .set_constructor(obj);
     obj

--- a/src/builtins/object.rs
+++ b/src/builtins/object.rs
@@ -25,8 +25,8 @@ pub fn object_constructor(
 ) -> vm::VMResult {
     if args.len() == 0 {
         let empty_obj = Value::object(
-            &mut vm.memory_allocator,
-            &vm.object_prototypes,
+            &mut vm.factory.memory_allocator,
+            &vm.factory.object_prototypes,
             FxHashMap::default(),
         );
         vm.stack.push(empty_obj.into());
@@ -36,8 +36,8 @@ pub fn object_constructor(
     match &args[0] {
         Value::Other(NULL) | Value::Other(UNDEFINED) => {
             let empty_obj = Value::object(
-                &mut vm.memory_allocator,
-                &vm.object_prototypes,
+                &mut vm.factory.memory_allocator,
+                &vm.factory.object_prototypes,
                 FxHashMap::default(),
             );
             vm.stack.push(empty_obj.into());

--- a/src/builtins/string.rs
+++ b/src/builtins/string.rs
@@ -21,12 +21,7 @@ pub fn string_prototype_split(
         .split(separator.as_str())
         .collect::<Vec<&str>>()
         .iter()
-        .map(|s| {
-            Property::new_data_simple(Value::string(
-                &mut vm.factory.memory_allocator,
-                s.to_string(),
-            ))
-        })
+        .map(|s| Property::new_data_simple(vm.factory.string(s.to_string())))
         .collect::<Vec<Property>>();
     let ary = Value::array(
         &mut vm.factory.memory_allocator,

--- a/src/builtins/string.rs
+++ b/src/builtins/string.rs
@@ -8,11 +8,9 @@ pub fn string_prototype_split(
     let string = cur_frame.this.into_str();
     let separator_ = args.get(0).map(|x| *x).unwrap_or(Value::undefined());
     if separator_.is_undefined() {
-        let ary = Value::array(
-            &mut vm.factory.memory_allocator,
-            &vm.factory.object_prototypes,
-            vec![Property::new_data_simple(cur_frame.this)],
-        );
+        let ary = vm
+            .factory
+            .array(vec![Property::new_data_simple(cur_frame.this)]);
         vm.stack.push(ary.into());
         return Ok(());
     }
@@ -23,11 +21,7 @@ pub fn string_prototype_split(
         .iter()
         .map(|s| Property::new_data_simple(vm.factory.string(s.to_string())))
         .collect::<Vec<Property>>();
-    let ary = Value::array(
-        &mut vm.factory.memory_allocator,
-        &vm.factory.object_prototypes,
-        elems,
-    );
+    let ary = vm.factory.array(elems);
     vm.stack.push(ary.into());
     Ok(())
 }

--- a/src/builtins/string.rs
+++ b/src/builtins/string.rs
@@ -9,8 +9,8 @@ pub fn string_prototype_split(
     let separator_ = args.get(0).map(|x| *x).unwrap_or(Value::undefined());
     if separator_.is_undefined() {
         let ary = Value::array(
-            &mut vm.memory_allocator,
-            &vm.object_prototypes,
+            &mut vm.factory.memory_allocator,
+            &vm.factory.object_prototypes,
             vec![Property::new_data_simple(cur_frame.this)],
         );
         vm.stack.push(ary.into());
@@ -21,9 +21,18 @@ pub fn string_prototype_split(
         .split(separator.as_str())
         .collect::<Vec<&str>>()
         .iter()
-        .map(|s| Property::new_data_simple(Value::string(&mut vm.memory_allocator, s.to_string())))
+        .map(|s| {
+            Property::new_data_simple(Value::string(
+                &mut vm.factory.memory_allocator,
+                s.to_string(),
+            ))
+        })
         .collect::<Vec<Property>>();
-    let ary = Value::array(&mut vm.memory_allocator, &vm.object_prototypes, elems);
+    let ary = Value::array(
+        &mut vm.factory.memory_allocator,
+        &vm.factory.object_prototypes,
+        elems,
+    );
     vm.stack.push(ary.into());
     Ok(())
 }

--- a/src/builtins/symbol.rs
+++ b/src/builtins/symbol.rs
@@ -44,8 +44,8 @@ pub fn symbol(
 
 pub fn symbol_constructor(vm: &mut VM, args: &[Value], _cur_frame: &frame::Frame) -> VMResult {
     let symbol = Value::symbol(
-        &mut vm.memory_allocator,
-        &vm.object_prototypes,
+        &mut vm.factory.memory_allocator,
+        &vm.factory.object_prototypes,
         args.get(0).map(|arg| arg.to_string()),
     );
     vm.stack.push(symbol.into());
@@ -54,8 +54,8 @@ pub fn symbol_constructor(vm: &mut VM, args: &[Value], _cur_frame: &frame::Frame
 
 pub fn symbol_for(vm: &mut VM, args: &[Value], _cur_frame: &frame::Frame) -> VMResult {
     let sym = vm.global_symbol_registry.for_(
-        &mut vm.memory_allocator,
-        &vm.object_prototypes,
+        &mut vm.factory.memory_allocator,
+        &vm.factory.object_prototypes,
         args.get(0).unwrap_or(&Value::undefined()).to_string(),
     );
     vm.stack.push(sym.into());
@@ -74,7 +74,7 @@ pub fn symbol_key_for(vm: &mut VM, args: &[Value], _cur_frame: &frame::Frame) ->
 
     let key = vm
         .global_symbol_registry
-        .key_for(&mut vm.memory_allocator, sym);
+        .key_for(&mut vm.factory.memory_allocator, sym);
     vm.stack.push(key.into());
     Ok(())
 }

--- a/src/builtins/symbol.rs
+++ b/src/builtins/symbol.rs
@@ -22,19 +22,14 @@ pub fn symbol(factory: &mut Factory) -> Value {
 }
 
 pub fn symbol_constructor(vm: &mut VM, args: &[Value], _cur_frame: &frame::Frame) -> VMResult {
-    let symbol = Value::symbol(
-        &mut vm.factory.memory_allocator,
-        &vm.factory.object_prototypes,
-        args.get(0).map(|arg| arg.to_string()),
-    );
+    let symbol = vm.factory.symbol(args.get(0).map(|arg| arg.to_string()));
     vm.stack.push(symbol.into());
     Ok(())
 }
 
 pub fn symbol_for(vm: &mut VM, args: &[Value], _cur_frame: &frame::Frame) -> VMResult {
     let sym = vm.global_symbol_registry.for_(
-        &mut vm.factory.memory_allocator,
-        &vm.factory.object_prototypes,
+        &mut vm.factory,
         args.get(0).unwrap_or(&Value::undefined()).to_string(),
     );
     vm.stack.push(sym.into());
@@ -51,9 +46,7 @@ pub fn symbol_key_for(vm: &mut VM, args: &[Value], _cur_frame: &frame::Frame) ->
         )));
     }
 
-    let key = vm
-        .global_symbol_registry
-        .key_for(&mut vm.factory.memory_allocator, sym);
+    let key = vm.global_symbol_registry.key_for(&mut vm.factory, sym);
     vm.stack.push(key.into());
     Ok(())
 }

--- a/src/builtins/symbol.rs
+++ b/src/builtins/symbol.rs
@@ -1,42 +1,21 @@
-use crate::gc::MemoryAllocator;
 use crate::vm::{
     error::RuntimeError,
     frame,
     jsvalue::value::*,
-    vm::{VMResult, VM},
+    vm::{Factory, VMResult, VM},
 };
 
-pub fn symbol(
-    memory_allocator: &mut MemoryAllocator,
-    object_prototypes: &ObjectPrototypes,
-) -> Value {
-    let obj = Value::builtin_function(
-        memory_allocator,
-        object_prototypes,
-        "Symbol".to_string(),
-        symbol_constructor,
-    );
+pub fn symbol(factory: &mut Factory) -> Value {
+    let obj = factory.builtin_function("Symbol", symbol_constructor);
 
     // Symbol.for
-    obj.set_property_by_string_key("for".to_string(), {
-        Value::builtin_function(
-            memory_allocator,
-            object_prototypes,
-            "for".to_string(),
-            symbol_for,
-        )
-    });
+    obj.set_property_by_string_key("for", { factory.builtin_function("for", symbol_for) });
     // Symbol.keyFor
-    obj.set_property_by_string_key("keyFor".to_string(), {
-        Value::builtin_function(
-            memory_allocator,
-            object_prototypes,
-            "keyFor".to_string(),
-            symbol_key_for,
-        )
+    obj.set_property_by_string_key("keyFor", {
+        factory.builtin_function("keyFor", symbol_key_for)
     });
 
-    obj.set_property_by_string_key("prototype".to_string(), object_prototypes.symbol);
+    obj.set_property_by_string_key("prototype", factory.object_prototypes.symbol);
     obj.get_property_by_str_key("prototype")
         .set_constructor(obj);
     obj

--- a/src/main.rs
+++ b/src/main.rs
@@ -145,7 +145,7 @@ fn repl(is_trace: bool) {
                         Some(ref mut frame) => {
                             frame.bytecode = iseq;
                             frame.exception_table = global_info.exception_table.clone();
-                            frame.append_from_function_info(&mut vm.memory_allocator, &global_info)
+                            frame.append_from_function_info(&mut vm.factory.memory_allocator, &global_info)
                         }
                         None => global_frame = Some(vm.create_global_frame(global_info, iseq)),
                     }

--- a/src/vm/error.rs
+++ b/src/vm/error.rs
@@ -1,7 +1,7 @@
 use super::super::builtins;
-use crate::gc::MemoryAllocator;
 use crate::lexer;
 use crate::vm::jsvalue::value::Value;
+use crate::vm::vm::Factory;
 use ansi_term::Colour;
 
 #[derive(Clone, PartialEq, Debug)]
@@ -16,18 +16,14 @@ pub enum RuntimeError {
 
 impl RuntimeError {
     /// convert RuntimeError -> Value
-    pub fn to_value2(self, memory_allocator: &mut MemoryAllocator) -> Value {
+    pub fn to_value(self, factory: &mut Factory) -> Value {
         match self {
             RuntimeError::Exception2(v, _) => v,
-            RuntimeError::Type(s) => Value::string(memory_allocator, s),
-            RuntimeError::General(s) => Value::string(memory_allocator, s),
-            RuntimeError::Reference(s) => {
-                Value::string(memory_allocator, format!("Reference error: {}", s))
-            }
-            RuntimeError::Unimplemented => {
-                Value::string(memory_allocator, "Unimplemented".to_string())
-            }
-            RuntimeError::Unknown => Value::string(memory_allocator, "Unknown".to_string()),
+            RuntimeError::Type(s) => factory.string(s),
+            RuntimeError::General(s) => factory.string(s),
+            RuntimeError::Reference(s) => factory.string(format!("Reference error: {}", s)),
+            RuntimeError::Unimplemented => factory.string("Unimplemented"),
+            RuntimeError::Unknown => factory.string("Unknown"),
         }
     }
 

--- a/src/vm/frame.rs
+++ b/src/vm/frame.rs
@@ -196,7 +196,7 @@ impl LexicalEnvironment {
         }
     }
 
-    pub fn new_global_initialized(mut factory: &mut Factory) -> Self {
+    pub fn new_global_initialized(factory: &mut Factory) -> Self {
         use crate::builtin::{deep_seq, parse_float, require};
         use crate::builtins;
 
@@ -207,12 +207,11 @@ impl LexicalEnvironment {
         let console = make_normal_object!(factory,
             log => true, false, true: log
         );
-        let object_constructor =
-            builtins::object::object(&mut factory.memory_allocator, &factory.object_prototypes);
-        let function_constructor = builtins::function::function(&mut factory);
-        let array_constructor = builtins::array::array(&mut factory);
-        let symbol_constructor = builtins::symbol::symbol(&mut factory);
-        let math_object = builtins::math::math(&mut factory);
+        let object_constructor = builtins::object::object(factory);
+        let function_constructor = builtins::function::function(factory);
+        let array_constructor = builtins::array::array(factory);
+        let symbol_constructor = builtins::symbol::symbol(factory);
+        let math_object = builtins::math::math(factory);
         LexicalEnvironment {
             record: EnvironmentRecord::Global(make_normal_object!(
                 factory,

--- a/src/vm/frame.rs
+++ b/src/vm/frame.rs
@@ -200,10 +200,10 @@ impl LexicalEnvironment {
         use crate::builtin::{deep_seq, parse_float, require};
         use crate::builtins;
 
-        let log = factory.builtin_function("log".to_string(), builtins::console::console_log);
-        let parse_float = factory.builtin_function("parseFloat".to_string(), parse_float);
-        let require = factory.builtin_function("require".to_string(), require);
-        let deep_seq = factory.builtin_function("__assert_deep_seq".to_string(), deep_seq);
+        let log = factory.builtin_function("log", builtins::console::console_log);
+        let parse_float = factory.builtin_function("parseFloat", parse_float);
+        let require = factory.builtin_function("require", require);
+        let deep_seq = factory.builtin_function("__assert_deep_seq", deep_seq);
         let console = make_normal_object!(factory,
             log => true, false, true: log
         );
@@ -211,8 +211,7 @@ impl LexicalEnvironment {
             builtins::object::object(&mut factory.memory_allocator, &factory.object_prototypes);
         let function_constructor = builtins::function::function(&mut factory);
         let array_constructor = builtins::array::array(&mut factory);
-        let symbol_constructor =
-            builtins::symbol::symbol(&mut factory.memory_allocator, &factory.object_prototypes);
+        let symbol_constructor = builtins::symbol::symbol(&mut factory);
         let math_object = builtins::math::math(&mut factory);
         LexicalEnvironment {
             record: EnvironmentRecord::Global(make_normal_object!(

--- a/src/vm/jsvalue/prototype.rs
+++ b/src/vm/jsvalue/prototype.rs
@@ -16,7 +16,7 @@ pub struct ObjectPrototypes {
 }
 
 impl ObjectPrototypes {
-    pub fn new(mut allocator: &mut MemoryAllocator) -> Self {
+    pub fn new(allocator: &mut MemoryAllocator) -> Self {
         let object_prototype = Value::Object(allocator.alloc(ObjectInfo {
             kind: ObjectKind::Ordinary,
             prototype: Value::null(),
@@ -49,7 +49,7 @@ impl ObjectPrototypes {
             let function_prototype_call = Value::builtin_function_with_proto(
                 allocator,
                 function_prototype,
-                "call".to_string(),
+                "call",
                 function::function_prototype_call,
             );
 
@@ -64,14 +64,14 @@ impl ObjectPrototypes {
             let index_of = Value::builtin_function_with_proto(
                 allocator,
                 function_prototype,
-                "indexOf".to_string(),
+                "indexOf",
                 builtins::string::string_prototype_index_of,
             );
 
             let split = Value::builtin_function_with_proto(
-                &mut allocator,
+                allocator,
                 function_prototype,
-                "split".to_string(),
+                "split",
                 builtins::string::string_prototype_split,
             );
 
@@ -85,16 +85,16 @@ impl ObjectPrototypes {
 
         let array_prototype = {
             let push = Value::builtin_function_with_proto(
-                &mut allocator,
+                allocator,
                 function_prototype,
-                "push".to_string(),
+                "push",
                 array::array_prototype_push,
             );
 
             let map = Value::builtin_function_with_proto(
-                &mut allocator,
+                allocator,
                 function_prototype,
-                "map".to_string(),
+                "map",
                 array::array_prototype_map,
             );
 

--- a/src/vm/jsvalue/prototype.rs
+++ b/src/vm/jsvalue/prototype.rs
@@ -16,8 +16,8 @@ pub struct ObjectPrototypes {
 }
 
 impl ObjectPrototypes {
-    pub fn new(memory_allocator: &mut MemoryAllocator) -> Self {
-        let object_prototype = Value::Object(memory_allocator.alloc(ObjectInfo {
+    pub fn new(mut allocator: &mut MemoryAllocator) -> Self {
+        let object_prototype = Value::Object(allocator.alloc(ObjectInfo {
             kind: ObjectKind::Ordinary,
             prototype: Value::null(),
             property: make_property_map!(),
@@ -25,7 +25,7 @@ impl ObjectPrototypes {
         }));
 
         let function_prototype = {
-            let function_prototype = Value::Object(memory_allocator.alloc(ObjectInfo {
+            let function_prototype = Value::Object(allocator.alloc(ObjectInfo {
                 kind: ObjectKind::Function(FunctionObjectInfo {
                     name: None,
                     kind: FunctionObjectKind::User(UserFunctionInfo {
@@ -47,7 +47,7 @@ impl ObjectPrototypes {
             }));
 
             let function_prototype_call = Value::builtin_function_with_proto(
-                memory_allocator,
+                allocator,
                 function_prototype,
                 "call".to_string(),
                 function::function_prototype_call,
@@ -62,20 +62,20 @@ impl ObjectPrototypes {
 
         let string_prototype = {
             let index_of = Value::builtin_function_with_proto(
-                memory_allocator,
+                allocator,
                 function_prototype,
                 "indexOf".to_string(),
                 builtins::string::string_prototype_index_of,
             );
 
             let split = Value::builtin_function_with_proto(
-                memory_allocator,
+                &mut allocator,
                 function_prototype,
                 "split".to_string(),
                 builtins::string::string_prototype_split,
             );
 
-            Value::Object(memory_allocator.alloc(ObjectInfo {
+            Value::Object(allocator.alloc(ObjectInfo {
                 kind: ObjectKind::Ordinary,
                 prototype: object_prototype,
                 property: make_property_map!(indexOf: index_of, split: split),
@@ -85,20 +85,20 @@ impl ObjectPrototypes {
 
         let array_prototype = {
             let push = Value::builtin_function_with_proto(
-                memory_allocator,
+                &mut allocator,
                 function_prototype,
                 "push".to_string(),
                 array::array_prototype_push,
             );
 
             let map = Value::builtin_function_with_proto(
-                memory_allocator,
+                &mut allocator,
                 function_prototype,
                 "map".to_string(),
                 array::array_prototype_map,
             );
 
-            Value::Object(memory_allocator.alloc(ObjectInfo {
+            Value::Object(allocator.alloc(ObjectInfo {
                 kind: ObjectKind::Array(ArrayObjectInfo { elems: vec![] }),
                 prototype: object_prototype,
                 property: make_property_map!(
@@ -111,7 +111,7 @@ impl ObjectPrototypes {
         };
 
         let symbol_prototype = {
-            Value::Object(memory_allocator.alloc(ObjectInfo {
+            Value::Object(allocator.alloc(ObjectInfo {
                 kind: ObjectKind::Ordinary,
                 prototype: object_prototype,
                 // TODO: https://tc39.github.io/ecma262/#sec-properties-of-the-symbol-prototype-object

--- a/src/vm/jsvalue/symbol.rs
+++ b/src/vm/jsvalue/symbol.rs
@@ -1,4 +1,5 @@
-use super::{super::super::gc::MemoryAllocator, prototype::ObjectPrototypes, value::Value};
+use super::value::Value;
+use crate::vm::vm::Factory;
 
 #[derive(Debug, Clone)]
 pub struct SymbolInfo {
@@ -25,25 +26,20 @@ impl GlobalSymbolRegistry {
         Self { list: vec![] }
     }
 
-    pub fn for_(
-        &mut self,
-        allocator: &mut MemoryAllocator,
-        object_prototypes: &ObjectPrototypes,
-        key: String,
-    ) -> Value {
+    pub fn for_(&mut self, factory: &mut Factory, key: String) -> Value {
         if let Some((_, sym)) = self.list.iter().find(|(key_, _)| key == *key_) {
             return *sym;
         }
 
-        let sym = Value::symbol(allocator, object_prototypes, Some(key.clone()));
+        let sym = factory.symbol(Some(key.clone()));
         self.list.push((key, sym));
 
         sym
     }
 
-    pub fn key_for(&mut self, allocator: &mut MemoryAllocator, sym: Value) -> Value {
+    pub fn key_for(&mut self, factory: &mut Factory, sym: Value) -> Value {
         if let Some((key, _)) = self.list.iter().find(|(_, sym_)| sym == *sym_) {
-            return Value::string(allocator, key.to_owned());
+            return factory.string(key.to_owned());
         }
 
         Value::undefined()

--- a/src/vm/jsvalue/value.rs
+++ b/src/vm/jsvalue/value.rs
@@ -7,7 +7,6 @@ pub use super::prototype::*;
 pub use super::symbol::*;
 use crate::builtin::BuiltinFuncTy2;
 use crate::gc;
-use crate::id::get_unique_id;
 use crate::vm::vm::Factory;
 pub use rustc_hash::FxHashMap;
 use std::ffi::CString;
@@ -162,38 +161,17 @@ impl Value {
         Value::Bool(if x { 1 } else { 0 })
     }
 
-    pub fn string(memory_allocator: &mut gc::MemoryAllocator, body: String) -> Self {
+    fn string(memory_allocator: &mut gc::MemoryAllocator, body: String) -> Self {
         Value::String(memory_allocator.alloc(CString::new(body).unwrap()))
     }
 
-    /*
-        pub fn builtin_function(
-            memory_allocator: &mut gc::MemoryAllocator,
-            object_prototypes: &ObjectPrototypes,
-            name: String,
-            func: BuiltinFuncTy2,
-        ) -> Self {
-            let name_prop = Value::string(memory_allocator, name.clone());
-            Value::Object(memory_allocator.alloc(ObjectInfo {
-                kind: ObjectKind::Function(FunctionObjectInfo {
-                    name: Some(name),
-                    kind: FunctionObjectKind::Builtin(func),
-                }),
-                prototype: object_prototypes.function,
-                property: make_property_map!(
-                    length => false, false, true : Value::Number(0.0),
-                    name   => false, false, true : name_prop
-                ),
-                sym_property: FxHashMap::default(),
-            }))
-        }
-    */
     pub fn builtin_function_with_proto(
         memory_allocator: &mut gc::MemoryAllocator,
         proto: Value,
-        name: String,
+        name: impl Into<String>,
         func: BuiltinFuncTy2,
     ) -> Self {
+        let name: String = name.into();
         let name_prop = Value::string(memory_allocator, name.clone());
         Value::Object(memory_allocator.alloc(ObjectInfo {
             kind: ObjectKind::Function(FunctionObjectInfo {
@@ -205,35 +183,6 @@ impl Value {
                 length => false, false, true : Value::Number(0.0),
                 name   => false, false, true : name_prop
             ),
-            sym_property: FxHashMap::default(),
-        }))
-    }
-
-    pub fn array(
-        memory_allocator: &mut gc::MemoryAllocator,
-        object_prototypes: &ObjectPrototypes,
-        elems: Vec<Property>,
-    ) -> Self {
-        Value::Object(memory_allocator.alloc(ObjectInfo {
-            kind: ObjectKind::Array(ArrayObjectInfo { elems }),
-            prototype: object_prototypes.array,
-            property: make_property_map!(),
-            sym_property: FxHashMap::default(),
-        }))
-    }
-
-    pub fn symbol(
-        memory_allocator: &mut gc::MemoryAllocator,
-        object_prototypes: &ObjectPrototypes,
-        description: Option<String>,
-    ) -> Self {
-        Value::Object(memory_allocator.alloc(ObjectInfo {
-            kind: ObjectKind::Symbol(SymbolInfo {
-                id: get_unique_id(),
-                description,
-            }),
-            prototype: object_prototypes.symbol,
-            property: make_property_map!(),
             sym_property: FxHashMap::default(),
         }))
     }

--- a/src/vm/jsvalue/value.rs
+++ b/src/vm/jsvalue/value.rs
@@ -464,9 +464,11 @@ impl Value {
         }
     }
 
-    pub fn set_property_by_string_key(&self, key: String, val: Value) {
+    pub fn set_property_by_string_key(&self, key: impl Into<String>, val: Value) {
         match self {
-            Value::Object(obj_info) => ObjectRef(*obj_info).set_property_by_string_key(key, val),
+            Value::Object(obj_info) => {
+                ObjectRef(*obj_info).set_property_by_string_key(key.into(), val)
+            }
             _ => {}
         }
     }

--- a/src/vm/jsvalue/value.rs
+++ b/src/vm/jsvalue/value.rs
@@ -71,6 +71,16 @@ macro_rules! make_property_map {
 
 #[macro_export]
 macro_rules! make_normal_object {
+    ($factory:expr) => { {
+        Value::Object($factory.alloc(
+            ObjectInfo {
+                kind: ObjectKind::Ordinary,
+                prototype: $factory.object_prototypes.object,
+                property: FxHashMap::default(),
+                sym_property: FxHashMap::default()
+            }
+        ))
+    } };
     ($memory_allocator:expr, $object_prototypes:expr) => { {
         Value::Object($memory_allocator.alloc(
             ObjectInfo {
@@ -86,6 +96,16 @@ macro_rules! make_normal_object {
             ObjectInfo {
                 kind: ObjectKind::Ordinary,
                 prototype: $object_prototypes.object,
+                property: make_property_map_sub!($($property_name, $val, $x, $y, $z),* ),
+                sym_property: FxHashMap::default()
+            }
+            ))
+    } };
+    ($factory:expr, $($property_name:ident => $x:ident, $y:ident, $z:ident : $val:expr),*) => { {
+        Value::Object($factory.alloc(
+            ObjectInfo {
+                kind: ObjectKind::Ordinary,
+                prototype: $factory.object_prototypes.object,
                 property: make_property_map_sub!($($property_name, $val, $x, $y, $z),* ),
                 sym_property: FxHashMap::default()
             }

--- a/src/vm/vm.rs
+++ b/src/vm/vm.rs
@@ -55,15 +55,16 @@ impl Factory {
         self.memory_allocator.alloc(data)
     }
 
+    /// Generate Value for built-in function.
     pub fn builtin_function(
         &mut self,
-        name: String,
+        name: impl Into<String>,
         func: crate::builtin::BuiltinFuncTy2,
     ) -> Value {
         Value::builtin_function(
             &mut self.memory_allocator,
             &self.object_prototypes,
-            name: String,
+            name.into(): String,
             func: crate::builtin::BuiltinFuncTy2,
         )
     }


### PR DESCRIPTION
This PR is a proposal for refactoring.
1. New struct `Factory`, which holds memory allocator and object prototypes, is introduced.
2. Some methods for generating several kinds of `Value`s are moved to `Value` to `Factory`.

before
```javascript
    let ary = Value::builtin_function(
        memory_allocator,
        object_prototypes,
        "Array".to_string(),
        array_constructor,
    );
```
after
```javascript
    let ary = factory.builtin_function("Array", array_constructor);
```

thank you.