### PR TITLE
Refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Rapidus
 
 [![CircleCI](https://circleci.com/gh/maekawatoshiki/rapidus.svg?style=shield)](https://circleci.com/gh/maekawatoshiki/rapidus)
-[![codecov](https://codecov.io/gh/maekawatoshiki/rapidus/branch/new-gen/graph/badge.svg)](https://codecov.io/gh/maekawatoshiki/rapidus/branch/new-gen)
+[![codecov](https://codecov.io/gh/maekawatoshiki/rapidus/branch/master/graph/badge.svg)](https://codecov.io/gh/maekawatoshiki/rapidus/branch/master)
 [![](http://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE)
 
 A toy JavaScript engine (now aiming for ES6).
@@ -102,44 +102,39 @@ undefined
 
 ```sh
 $ cargo run -- --trace
-> function fact(n) { if (n<2) { return n } else { return n*fact(n-1) } }
- tryst    tryret   scope stack   top            PC   INST
- None              1     0                      0000 CreateContext
- None              1     0                      0001 DeclVar 'fact'
- None              1     0                      0006 PushConst [Function]
- None              1     1     [Function]       000b UpdateParentScope
- None              1     1     [Function]       000c SetValue 'fact'
- None              1     0                      0011 End
-stack trace:
+> function fibo(x) { if (x<2) return 1; return fibo(x-1)+fibo(x-2)}
+00020m 00000 Return                    <empty>
 undefined
-> fact(3)
- tryst    tryret   scope stack   top            PC   INST
- None              1     0                      0000 CreateContext
- None              1     0                      0001 PushInt8 3
- None              1     1     3                0003 GetValue 'fact'
- None              1     2     [Function]       0008 Call 1 params
- None              2     0                      0000 CreateContext
- None              2     0                      0001 GetValue 'n'
- None              2     1     3                0006 PushInt8 2
- None              2     2     2                0008 Lt
- None              2     1     false            0009 JmpIfFalse 0019
- None              2     0                      0019 GetValue 'n'
- None              2     1     3                001e GetValue 'n'
- None              2     2     3                0023 PushInt8 1
- None              2     3     1                0025 Sub
- None              2     2     2                0026 GetValue 'fact'
- None              2     3     [Function]       002b Call 1 params
- None              2     2     2                0030 Mul
- None              2     1     6                0031 Return
-stack trace: 6
- None              1     1     6                000d End
-stack trace: 6
-6
-                   |     |     |                 |  bytecode instruction
-                   |     |     |                 \- program counter
-                   |     |     \------------------- value on the stack top
-                   |     \------------------------- execution stack depth
-                   \------------------------------- scope stack depth
+> fibo(3)
+00009m 00000 PushInt8 3                <empty>
+00015m 00002 GetValue 'fibo'           3.0
+00066m 00007 Call 1                    Function
+--> call function
+  module_id:0 func_id:0
+00007m 00000 GetValue 'x'              <empty>
+00001m 00005 PushInt8 2                3.0
+00013m 00007 Lt                        2.0
+
+...
+
+00001m 00007 Lt                        2.0
+00000m 00008 JmpIfFalse 00016          true
+00000m 00013 PushInt8 1                <empty>
+00167m 00015 Return                    1.0
+<-- return value(1.0)
+  module_id:0 func_id:2
+00001m 00052 Add                       1.0
+00044m 00053 Return                    3.0
+<-- return value(3.0)
+  module_id:0 func_id:0
+00000m 00012 Return                    3.0
+3
+> 
+   |     |     |                        | 
+   |     |     |                        \- value at the top of exec stack
+   |     |     \-------------------------- instruction
+   |     \-------------------------------- program counter
+   \-------------------------------------- execution time per inst. (in microsecs)
 ```
 
 ## Building on other platforms

--- a/examples/fibo.js
+++ b/examples/fibo.js
@@ -1,6 +1,6 @@
-function fibo(x) {
+function fibo (x) {
   if (x < 2) return 1
   return fibo(x - 1) + fibo(x - 2)
 }
 
-console.log(fibo(22))
+console.log(fibo(30))

--- a/examples/fibo.js
+++ b/examples/fibo.js
@@ -1,0 +1,6 @@
+function fibo(x) {
+  if (x < 2) return 1
+  return fibo(x - 1) + fibo(x - 2)
+}
+
+console.log(fibo(22))

--- a/examples/func_proto_call.js
+++ b/examples/func_proto_call.js
@@ -6,12 +6,12 @@ function A(x, y) {
 function B() {
   A.call(this, 1, 2)
 }
-
+/*
 function C() {
   A.apply(this, [3, 4])
 }
-
+*/
 var b = new B()
-var c = new C()
+//var c = new C()
 console.log(b.x, b.y)
-console.log(c.x, c.y)
+//console.log(c.x, c.y)

--- a/examples/known_bugs.js
+++ b/examples/known_bugs.js
@@ -1,17 +1,3 @@
-var a = 5
-a += ' ' + undefined
-console.log(a) // -> NaN in rapidus
-
-var f = function() {
-  this.name = 'ok'
-  this.g = function() {
-    console.log(this.name)
-  }
-  //function g() { return 'NG' }
-}
-
-new f().g() // -> error in rapidus (parsed as "new (f().g())" )
-
 label1: // -> this label is invalid in node.js.
 var a = 0
 for (let i = 0; i < 10; i++) {

--- a/src/builtin.rs
+++ b/src/builtin.rs
@@ -1,30 +1,21 @@
 use crate::vm::{
-    exec_context::ExecContext,
     jsvalue::value::*,
     vm::{VMValueResult, VM},
 };
 
-pub type BuiltinFuncTy = fn(&mut VM, &[Value], Value, &mut ExecContext) -> VMValueResult;
+pub type BuiltinFuncTy = fn(&mut VM, &[Value], Value) -> VMValueResult;
 
-pub fn parse_float(
-    _vm: &mut VM,
-    args: &[Value],
-    _this: Value,
-    _cur_frame: &mut ExecContext,
-) -> VMValueResult {
+pub fn parse_float(_vm: &mut VM, args: &[Value], _this: Value) -> VMValueResult {
     let string = args.get(0).unwrap_or(&Value::undefined()).to_string();
     let val = Value::Number(string.parse::<f64>().unwrap_or(::std::f64::NAN));
     Ok(val)
 }
 
-pub fn deep_seq(
-    _vm: &mut VM,
-    args: &[Value],
-    _this: Value,
-    cur_frame: &mut ExecContext,
-) -> VMValueResult {
+pub fn deep_seq(vm: &mut VM, args: &[Value], _this: Value) -> VMValueResult {
     if args.len() != 2 {
-        return Err(cur_frame.error_general("__assert_deep_seq(): Two arguments are needed."));
+        return Err(vm
+            .current_context
+            .error_general("__assert_deep_seq(): Two arguments are needed."));
     };
     let lval = args.get(0).unwrap();
     let rval = args.get(1).unwrap();
@@ -95,32 +86,31 @@ fn deep_seq_bool(lval: &Value, rval: &Value) -> bool {
     }
 }
 
-pub fn require(
-    vm: &mut VM,
-    args: &[Value],
-    _this: Value,
-    cur_frame: &mut ExecContext,
-) -> VMValueResult {
+pub fn require(vm: &mut VM, args: &[Value], _this: Value) -> VMValueResult {
     let file_name = {
-        let val = args
-            .get(0)
-            .ok_or(cur_frame.error_general("require():One argument is needed."))?;
+        let val = args.get(0).ok_or(
+            vm.current_context
+                .error_general("require():One argument is needed."),
+        )?;
         match val {
             Value::String(_) => val.to_string(),
             _ => {
-                return Err(cur_frame.error_type("require():An argument should be string."));
+                return Err(vm
+                    .current_context
+                    .error_type("require():An argument should be string."));
             }
         }
     };
 
     use crate::parser::Parser;
     let mut parser = Parser::load_module(file_name.clone())
-        .map_err(|e| return cur_frame.error_general(format!("{:?}", e)))?;
+        .map_err(|e| return vm.current_context.error_general(format!("{:?}", e)))?;
     let absolute_path = parser.file_name.clone();
 
     let node = r#try!(parser.parse_all().map_err(|parse_err| {
         parser.handle_error(&parse_err);
-        cur_frame.error_general(format!("Error in parsing module \"{}\"", file_name))
+        vm.current_context
+            .error_general(format!("Error in parsing module \"{}\"", file_name))
     }));
 
     let mut iseq = vec![];
@@ -131,7 +121,8 @@ pub fn require(
         .map_err(|codegen_err| {
             let Error { msg, token_pos, .. } = codegen_err;
             parser.show_error_at(token_pos, msg);
-            cur_frame.error_general(format!("Error in parsing module \"{}\"", file_name))
+            vm.current_context
+                .error_general(format!("Error in parsing module \"{}\"", file_name))
         }));
     let script_info = parser.into_script_info();
     vm.script_info.push((id, script_info));
@@ -149,12 +140,11 @@ pub fn require(
         outer: Some(vm.global_environment),
     };
 
-    let mut frame = vm
-        .prepare_frame_for_function_invokation(
+    let mut context = vm
+        .prepare_context_for_function_invokation(
             &user_func_info,
             args: &[Value],
             Value::undefined(),
-            cur_frame,
         )?
         .module_call(true);
 
@@ -165,17 +155,17 @@ pub fn require(
         id       => false, false, false: id_object,
         exports  => true,  false, false: empty_object
     );
-    frame.lex_env_mut().set_own_value("module", module)?;
+    context.lex_env_mut().set_own_value("module", module)?;
 
     if vm.is_trace {
         println!("--> call module");
         println!(
             "  module_id:{} func_id:{}",
-            frame.module_func_id, frame.func_id
+            context.module_func_id, context.func_id
         );
     };
 
-    *cur_frame = frame;
+    vm.current_context = context;
 
     Ok(Value::empty())
 }

--- a/src/builtin.rs
+++ b/src/builtin.rs
@@ -90,14 +90,14 @@ pub fn require(vm: &mut VM, args: &[Value], _this: Value) -> VMValueResult {
     let file_name = {
         let val = args.get(0).ok_or(
             vm.current_context
-                .error_general("require():One argument is needed."),
+                .error_general("require(): One argument is needed."),
         )?;
         match val {
             Value::String(_) => val.to_string(),
             _ => {
                 return Err(vm
                     .current_context
-                    .error_type("require():An argument should be string."));
+                    .error_type("require(): An argument should be string."));
             }
         }
     };

--- a/src/builtins/array.rs
+++ b/src/builtins/array.rs
@@ -87,7 +87,7 @@ pub fn array_prototype_map(vm: &mut VM, args: &[Value], this: Value) -> VMValueR
     let mut new_ary = vec![];
 
     for i in 0..ary_info.get_length() {
-        args_for_callback[0] = vm.get_property(this, Value::Number(i as f64))?; // 'i'th element may be getter
+        args_for_callback[0] = vm.get_property_by_value(this, Value::Number(i as f64))?; // 'i'th element may be getter
         args_for_callback[1] = Value::Number(i as f64);
 
         let val = vm.call_function(callback, &args_for_callback, Value::undefined())?;

--- a/src/builtins/array.rs
+++ b/src/builtins/array.rs
@@ -1,5 +1,4 @@
 use crate::vm::{
-    exec_context::ExecContext,
     jsvalue::{object::Property, value::Value},
     vm::{Factory, VMValueResult, VM},
 };
@@ -12,12 +11,7 @@ pub fn array(factory: &mut Factory) -> Value {
     )
 }
 
-pub fn array_constructor(
-    vm: &mut VM,
-    args: &[Value],
-    _this: Value,
-    _cur_frame: &mut ExecContext,
-) -> VMValueResult {
+pub fn array_constructor(vm: &mut VM, args: &[Value], _this: Value) -> VMValueResult {
     let arg_length = args.len();
     let props = {
         match arg_length {
@@ -44,14 +38,9 @@ pub fn array_constructor(
     Ok(val)
 }
 
-pub fn array_prototype_join(
-    vm: &mut VM,
-    args: &[Value],
-    this: Value,
-    cur_frame: &mut ExecContext,
-) -> VMValueResult {
+pub fn array_prototype_join(vm: &mut VM, args: &[Value], this: Value) -> VMValueResult {
     if !this.is_array_object() {
-        return Err(cur_frame.error_unknown());
+        return Err(vm.current_context.error_unknown());
     }
 
     let ary_info = this.as_array_mut();
@@ -65,14 +54,9 @@ pub fn array_prototype_join(
     Ok(val)
 }
 
-pub fn array_prototype_push(
-    _vm: &mut VM,
-    args: &[Value],
-    this: Value,
-    cur_frame: &mut ExecContext,
-) -> VMValueResult {
+pub fn array_prototype_push(vm: &mut VM, args: &[Value], this: Value) -> VMValueResult {
     if !this.is_array_object() {
-        return Err(cur_frame.error_unknown());
+        return Err(vm.current_context.error_unknown());
     }
 
     let ary_info = this.as_array_mut();
@@ -86,14 +70,9 @@ pub fn array_prototype_push(
     Ok(val)
 }
 
-pub fn array_prototype_map(
-    vm: &mut VM,
-    args: &[Value],
-    this: Value,
-    cur_frame: &mut ExecContext,
-) -> VMValueResult {
+pub fn array_prototype_map(vm: &mut VM, args: &[Value], this: Value) -> VMValueResult {
     if !this.is_array_object() {
-        return Err(cur_frame.error_unknown());
+        return Err(vm.current_context.error_unknown());
     }
 
     let ary_info = this.as_array_mut();
@@ -108,10 +87,10 @@ pub fn array_prototype_map(
     let mut new_ary = vec![];
 
     for i in 0..ary_info.get_length() {
-        args_for_callback[0] = vm.get_property(this, Value::Number(i as f64), cur_frame)?; // 'i'th element may be getter
+        args_for_callback[0] = vm.get_property(this, Value::Number(i as f64))?; // 'i'th element may be getter
         args_for_callback[1] = Value::Number(i as f64);
 
-        let val = vm.call_function(callback, &args_for_callback, Value::undefined(), cur_frame)?;
+        let val = vm.call_function(callback, &args_for_callback, Value::undefined())?;
         if val.is_empty() {
             unreachable!("EMPTY")
         };

--- a/src/builtins/console.rs
+++ b/src/builtins/console.rs
@@ -1,5 +1,4 @@
 use crate::vm::{
-    exec_context::ExecContext,
     jsvalue::value::{
         cstrp_to_str, AccessorProperty, DataProperty, ObjectKind, ObjectRef, Property, Value,
         EMPTY, NULL, UNDEFINED, UNINITIALIZED,
@@ -8,12 +7,7 @@ use crate::vm::{
     vm::VM,
 };
 
-pub fn console_log(
-    _vm: &mut VM,
-    args: &[Value],
-    _this: Value,
-    _cur_frame: &mut ExecContext,
-) -> VMValueResult {
+pub fn console_log(_vm: &mut VM, args: &[Value], _this: Value) -> VMValueResult {
     let args_len = args.len();
 
     for i in 0..args_len {

--- a/src/builtins/console.rs
+++ b/src/builtins/console.rs
@@ -97,10 +97,9 @@ pub fn debug_print(val: &Value, nest: bool) {
                     "Symbol({})",
                     info.description.as_ref().unwrap_or(&"".to_string())
                 ),
-                ObjectKind::Error(ref _info) => print!(
-                    "Error({})",
-                    obj_info.get_property_by_str_key("message").to_string()
-                ),
+                ObjectKind::Error(ref _info) => {
+                    print!("Error({})", obj_info.get_property("message").to_string())
+                }
                 ObjectKind::Function(ref func_info) => {
                     if let Some(ref name) = func_info.name {
                         print!("[Function: {}]", name);

--- a/src/builtins/error.rs
+++ b/src/builtins/error.rs
@@ -1,5 +1,4 @@
 use crate::vm::{
-    exec_context::ExecContext,
     jsvalue::value::Value,
     vm::{Factory, VMValueResult, VM},
 };
@@ -12,12 +11,7 @@ pub fn error(factory: &mut Factory) -> Value {
     )
 }
 
-pub fn error_constructor(
-    vm: &mut VM,
-    args: &[Value],
-    _this: Value,
-    _cur_frame: &mut ExecContext,
-) -> VMValueResult {
+pub fn error_constructor(vm: &mut VM, args: &[Value], _this: Value) -> VMValueResult {
     let message = if args.len() == 0 {
         "".to_string()
     } else {

--- a/src/builtins/function.rs
+++ b/src/builtins/function.rs
@@ -1,5 +1,4 @@
 use crate::vm::{
-    exec_context::ExecContext,
     jsvalue::{function::UserFunctionInfo, value::Value},
     vm::{Factory, VMValueResult, VM},
 };
@@ -13,24 +12,14 @@ pub fn function(factory: &mut Factory) -> Value {
 }
 
 // TODO: https://www.ecma-international.org/ecma-262/9.0/index.html#sec-function-constructor
-pub fn function_constructor(
-    vm: &mut VM,
-    _args: &[Value],
-    _this: Value,
-    cur_frame: &mut ExecContext,
-) -> VMValueResult {
-    let info = UserFunctionInfo::new(cur_frame.module_func_id);
+pub fn function_constructor(vm: &mut VM, _args: &[Value], _this: Value) -> VMValueResult {
+    let info = UserFunctionInfo::new(vm.current_context.module_func_id);
     let func = vm.factory.function(None, info);
     Ok(func)
 }
 
-pub fn function_prototype_call(
-    vm: &mut VM,
-    args: &[Value],
-    this: Value,
-    cur_frame: &mut ExecContext,
-) -> VMValueResult {
+pub fn function_prototype_call(vm: &mut VM, args: &[Value], this: Value) -> VMValueResult {
     let this_arg = *args.get(0).unwrap_or(&Value::undefined());
     let func = this;
-    vm.call_function(func, args.get(1..).unwrap_or(&[]), this_arg, cur_frame)
+    vm.call_function(func, args.get(1..).unwrap_or(&[]), this_arg)
 }

--- a/src/builtins/math.rs
+++ b/src/builtins/math.rs
@@ -1,8 +1,5 @@
-use crate::vm::{
-    exec_context::ExecContext,
-    jsvalue::value::Value,
-    vm::{Factory, VMValueResult, VM},
-};
+use crate::vm::jsvalue::value::Value;
+use crate::vm::vm::{Factory, VMValueResult, VM};
 use rand::random;
 
 pub fn math(factory: &mut Factory) -> Value {
@@ -13,12 +10,7 @@ pub fn math(factory: &mut Factory) -> Value {
     )
 }
 
-pub fn math_random(
-    _vm: &mut VM,
-    _args: &[Value],
-    _this: Value,
-    _cur_frame: &mut ExecContext,
-) -> VMValueResult {
+pub fn math_random(_vm: &mut VM, _args: &[Value], _this: Value) -> VMValueResult {
     let val = Value::Number(random::<f64>());
     Ok(val)
 }

--- a/src/builtins/object.rs
+++ b/src/builtins/object.rs
@@ -1,5 +1,4 @@
 use crate::vm::{
-    exec_context::ExecContext,
     jsvalue::value::*,
     vm::{Factory, VMValueResult, VM},
 };
@@ -13,12 +12,7 @@ pub fn object(factory: &mut Factory) -> Value {
     )
 }
 
-pub fn object_constructor(
-    vm: &mut VM,
-    args: &[Value],
-    _this: Value,
-    _cur_frame: &mut ExecContext,
-) -> VMValueResult {
+pub fn object_constructor(vm: &mut VM, args: &[Value], _this: Value) -> VMValueResult {
     if args.len() == 0 {
         let empty_obj = vm.factory.object(FxHashMap::default());
         vm.stack.push(empty_obj.into());

--- a/src/builtins/object.rs
+++ b/src/builtins/object.rs
@@ -15,7 +15,7 @@ pub fn object(factory: &mut Factory) -> Value {
 pub fn object_constructor(vm: &mut VM, args: &[Value], _this: Value) -> VMValueResult {
     if args.len() == 0 {
         let empty_obj = vm.factory.object(FxHashMap::default());
-        vm.stack.push(empty_obj.into());
+        vm.current_context.stack.push(empty_obj.into());
         return Ok(empty_obj);
     }
 

--- a/src/builtins/string.rs
+++ b/src/builtins/string.rs
@@ -1,16 +1,10 @@
 use crate::vm::{
-    exec_context::ExecContext,
     jsvalue::value::{Property, Value},
     vm::VMValueResult,
     vm::VM,
 };
 
-pub fn string_prototype_split(
-    vm: &mut VM,
-    args: &[Value],
-    this: Value,
-    _cur_frame: &mut ExecContext,
-) -> VMValueResult {
+pub fn string_prototype_split(vm: &mut VM, args: &[Value], this: Value) -> VMValueResult {
     let string = this.into_str();
     let separator_ = args.get(0).map(|x| *x).unwrap_or(Value::undefined());
     if separator_.is_undefined() {
@@ -28,12 +22,7 @@ pub fn string_prototype_split(
     Ok(ary)
 }
 
-pub fn string_prototype_index_of(
-    _vm: &mut VM,
-    args: &[Value],
-    this: Value,
-    _cur_frame: &mut ExecContext,
-) -> VMValueResult {
+pub fn string_prototype_index_of(_vm: &mut VM, args: &[Value], this: Value) -> VMValueResult {
     let string = this.into_str();
     let search_string = args.get(0).unwrap_or(&Value::undefined()).to_string();
     let position = args.get(1).unwrap_or(&Value::Number(0.0)).into_number() as usize;

--- a/src/builtins/symbol.rs
+++ b/src/builtins/symbol.rs
@@ -11,11 +11,9 @@ pub fn symbol(factory: &mut Factory) -> Value {
     );
 
     // Symbol.for
-    obj.set_property_by_string_key("for", { factory.builtin_function("for", symbol_for) });
+    obj.set_property("for", factory.builtin_function("for", symbol_for));
     // Symbol.keyFor
-    obj.set_property_by_string_key("keyFor", {
-        factory.builtin_function("keyFor", symbol_key_for)
-    });
+    obj.set_property("keyFor", factory.builtin_function("keyFor", symbol_key_for));
     obj
 }
 

--- a/src/builtins/symbol.rs
+++ b/src/builtins/symbol.rs
@@ -1,5 +1,4 @@
 use crate::vm::{
-    exec_context::ExecContext,
     jsvalue::value::*,
     vm::{Factory, VMValueResult, VM},
 };
@@ -20,22 +19,12 @@ pub fn symbol(factory: &mut Factory) -> Value {
     obj
 }
 
-pub fn symbol_constructor(
-    vm: &mut VM,
-    args: &[Value],
-    _this: Value,
-    _cur_frame: &mut ExecContext,
-) -> VMValueResult {
+pub fn symbol_constructor(vm: &mut VM, args: &[Value], _this: Value) -> VMValueResult {
     let symbol = vm.factory.symbol(args.get(0).map(|arg| arg.to_string()));
     Ok(symbol)
 }
 
-pub fn symbol_for(
-    vm: &mut VM,
-    args: &[Value],
-    _this: Value,
-    _cur_frame: &mut ExecContext,
-) -> VMValueResult {
+pub fn symbol_for(vm: &mut VM, args: &[Value], _this: Value) -> VMValueResult {
     let symbol = vm.global_symbol_registry.for_(
         &mut vm.factory,
         args.get(0).unwrap_or(&Value::undefined()).to_string(),
@@ -43,16 +32,13 @@ pub fn symbol_for(
     Ok(symbol)
 }
 
-pub fn symbol_key_for(
-    vm: &mut VM,
-    args: &[Value],
-    _this: Value,
-    cur_frame: &mut ExecContext,
-) -> VMValueResult {
+pub fn symbol_key_for(vm: &mut VM, args: &[Value], _this: Value) -> VMValueResult {
     let sym = args.get(0).map(|x| *x).unwrap_or(Value::undefined());
 
     if !sym.is_symbol() {
-        return Err(cur_frame.error_type(format!("{} is not symbol", sym.debug_string(true))));
+        return Err(vm
+            .current_context
+            .error_type(format!("{} is not symbol", sym.debug_string(true))));
     }
 
     let key = vm.global_symbol_registry.key_for(&mut vm.factory, sym);

--- a/src/gc.rs
+++ b/src/gc.rs
@@ -137,8 +137,8 @@ impl MemoryAllocator {
             }
             GCState::Marking => {
                 // println!("start marking: {:?}", markset);
-
-                for root in self.roots.clone() {
+                let roots = std::mem::replace(&mut self.roots, FxHashSet::default());
+                for root in roots {
                     self.allocated_memory.insert(root, MarkState::Black);
                     unsafe { &*root.0 }.trace(self, &mut markset);
                 }

--- a/src/gc.rs
+++ b/src/gc.rs
@@ -1,10 +1,7 @@
 use crate::vm::{
     constant, exec_context,
     exec_context::{EnvironmentRecord, ExecContext, LexicalEnvironment},
-    jsvalue::{
-        function, object, prototype,
-        value::{BoxedValue, Value},
-    },
+    jsvalue::{function, object, prototype, value::Value},
 };
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::hash::{Hash, Hasher};
@@ -96,7 +93,7 @@ impl MemoryAllocator {
         global: exec_context::LexicalEnvironmentRef,
         object_prototypes: &prototype::ObjectPrototypes,
         constant_table: &constant::ConstantTable,
-        stack: &Vec<BoxedValue>,
+        //stack: &Vec<BoxedValue>,
         cur_context: &exec_context::ExecContext,
         saved_context: &Vec<exec_context::ExecContext>,
     ) {
@@ -119,12 +116,12 @@ impl MemoryAllocator {
                 object_prototypes.array.initial_trace(&mut markset);
 
                 constant_table.initial_trace(&mut markset);
-
-                for val_boxed in stack {
-                    let val: Value = (*val_boxed).into();
-                    val.initial_trace(&mut markset);
-                }
-
+                /*
+                                for val_boxed in stack {
+                                    let val: Value = (*val_boxed).into();
+                                    val.initial_trace(&mut markset);
+                                }
+                */
                 for context in saved_context {
                     context.initial_trace(&mut markset);
                     context.this.initial_trace(&mut markset);
@@ -242,6 +239,10 @@ impl GcTarget for ExecContext {
         mark!(markset, self.variable_environment.as_ptr());
         for env in &self.saved_lexical_environment {
             mark!(markset, env.as_ptr());
+        }
+        for val_boxed in &self.stack {
+            let val: Value = (*val_boxed).into();
+            val.initial_trace(markset);
         }
     }
 

--- a/src/gc.rs
+++ b/src/gc.rs
@@ -97,8 +97,8 @@ impl MemoryAllocator {
         object_prototypes: &prototype::ObjectPrototypes,
         constant_table: &constant::ConstantTable,
         stack: &Vec<BoxedValue>,
-        cur_frame: &exec_context::ExecContext,
-        saved_frame: &Vec<exec_context::ExecContext>,
+        cur_context: &exec_context::ExecContext,
+        saved_context: &Vec<exec_context::ExecContext>,
     ) {
         let mut markset = MarkSet::default();
 
@@ -110,8 +110,8 @@ impl MemoryAllocator {
                 markset.insert(GcTargetKey(global.as_ptr()));
                 global.initial_trace(&mut markset);
 
-                cur_frame.initial_trace(&mut markset);
-                cur_frame.this.initial_trace(&mut markset);
+                cur_context.initial_trace(&mut markset);
+                cur_context.this.initial_trace(&mut markset);
 
                 object_prototypes.object.initial_trace(&mut markset);
                 object_prototypes.function.initial_trace(&mut markset);
@@ -125,9 +125,9 @@ impl MemoryAllocator {
                     val.initial_trace(&mut markset);
                 }
 
-                for frame in saved_frame {
-                    frame.initial_trace(&mut markset);
-                    frame.this.initial_trace(&mut markset);
+                for context in saved_context {
+                    context.initial_trace(&mut markset);
+                    context.this.initial_trace(&mut markset);
                 }
 
                 // println!("initial mark: {:?}", markset);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 extern crate rapidus;
 use rapidus::parser;
-use rapidus::{vm, vm::exec_context, vm::jsvalue::value::Value, vm::vm::VM};
+use rapidus::{vm, vm::exec_context, vm::vm::VM};
 
 extern crate libc;
 
@@ -78,13 +78,6 @@ fn main() {
     if let Err(e) = vm.run_global(global_info, iseq) {
         vm.show_error_message(e);
     }
-
-    if is_debug {
-        for (i, val_boxed) in vm.current_context.stack.iter().enumerate() {
-            let val: Value = (*val_boxed).into();
-            println!("stack remaining: [{}]: {:?}", i, val);
-        }
-    }
 }
 
 fn repl(is_trace: bool) {
@@ -142,10 +135,7 @@ fn repl(is_trace: bool) {
                         Err(e) => {
                             let val = e.to_value(&mut vm.factory);
                             if val.is_error_object() {
-                                println!(
-                                    "Error: {}",
-                                    val.get_property_by_str_key("message").to_string()
-                                );
+                                println!("Error: {}", val.get_property("message"));
                             } else {
                                 println!("Thrown: {}", val.to_string())
                             };

--- a/src/main.rs
+++ b/src/main.rs
@@ -322,6 +322,16 @@ mod tests {
     }
 
     #[test]
+    fn function_methods() {
+        assert_file("function_methods")
+    }
+
+    #[test]
+    fn string_methods() {
+        assert_file("string_methods")
+    }
+
+    #[test]
     fn runtime_error1() {
         runtime_error("let a = {}; a.b.c");
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,8 @@
+#![feature(test)]
 extern crate rapidus;
 use rapidus::parser;
 use rapidus::{vm, vm::exec_context, vm::vm::VM};
+extern crate test;
 
 extern crate libc;
 
@@ -344,5 +346,11 @@ mod tests {
     #[test]
     fn runtime_error5() {
         runtime_error("let a = {}; a(5)");
+    }
+
+    use test::Bencher;
+    #[bench]
+    fn bench_fibo(b: &mut Bencher) {
+        b.iter(|| assert_file("fibo"));
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -70,7 +70,7 @@ impl Parser {
     /// * `file_name` - A module file name.
     pub fn load_module(file_name: impl Into<String>) -> Result<Parser, Error> {
         let file_name = file_name.into();
-        let path = Path::new(&file_name);
+        let path = Path::new(&file_name).with_extension("js");
         let absolute_path = match path.canonicalize() {
             Ok(path) => path,
             Err(ioerr) => {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -47,12 +47,13 @@ pub struct Parser {
 }
 
 #[derive(Clone, Debug)]
+/// Information about a script (module), e.g. file name, source text, and correspondence between char postions and line numbers.
 pub struct ScriptInfo {
     /// File name with Absolute path.
     pub file_name: String,
     /// Script text.
     pub code: String,
-    /// A vector of (column_number, line_number).
+    /// Correspondence between char postions and line numbers.
     pub pos_line_list: Vec<(usize, usize)>,
 }
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -74,7 +74,12 @@ pub fn execute_script(text: String) -> String {
 
     let func_info = vm.compile(&node, &mut iseq, true, 0).unwrap();
     vm.run_global(func_info, iseq).unwrap();
-    let val: Value = vm.stack.pop().unwrap_or(Value::undefined().into()).into();
+    let val: Value = vm
+        .current_context
+        .stack
+        .pop()
+        .unwrap_or(Value::undefined().into())
+        .into();
     val.debug_string(true)
 }
 

--- a/src/vm/error.rs
+++ b/src/vm/error.rs
@@ -11,6 +11,7 @@ pub struct RuntimeError {
     pub inst_pc: usize,
     /// Function id where the error raised.
     pub func_id: usize,
+    /// Module function id where the error raised.
     pub module_func_id: usize,
 }
 

--- a/src/vm/error.rs
+++ b/src/vm/error.rs
@@ -25,12 +25,12 @@ pub enum ErrorKind {
 }
 
 impl RuntimeError {
-    pub fn new(kind: ErrorKind, frame: &ExecContext) -> RuntimeError {
+    pub fn new(kind: ErrorKind, context: &ExecContext) -> RuntimeError {
         RuntimeError {
             kind,
-            inst_pc: frame.current_inst_pc,
-            func_id: frame.func_id,
-            module_func_id: frame.module_func_id,
+            inst_pc: context.current_inst_pc,
+            func_id: context.func_id,
+            module_func_id: context.module_func_id,
         }
     }
 
@@ -51,10 +51,10 @@ impl RuntimeError {
         RuntimeError::default(ErrorKind::Reference(msg.into()))
     }
 
-    pub fn error_add_info(mut self, frame: &ExecContext) -> RuntimeError {
-        self.func_id = frame.func_id;
-        self.module_func_id = frame.module_func_id;
-        self.inst_pc = frame.pc;
+    pub fn error_add_info(mut self, context: &ExecContext) -> RuntimeError {
+        self.func_id = context.func_id;
+        self.module_func_id = context.module_func_id;
+        self.inst_pc = context.pc;
         self
     }
 

--- a/src/vm/exec_context.rs
+++ b/src/vm/exec_context.rs
@@ -6,7 +6,7 @@ use crate::vm::error::ErrorKind;
 use crate::vm::error::RuntimeError;
 use crate::vm::jsvalue::function::Exception;
 use crate::vm::jsvalue::value::{BoxedValue, Value};
-use crate::vm::vm::{Factory, VMResult};
+use crate::vm::vm::{CallMode, Factory, VMResult};
 use rustc_hash::FxHashMap;
 use std::ops::{Deref, DerefMut};
 
@@ -26,10 +26,11 @@ pub struct ExecContext {
     pub this: Value,
     /// If true, calling JS function as a constructor.
     pub constructor_call: bool,
+    pub call_mode: CallMode,
     /// If true, calling JS function as a module.
-    pub module_call: bool,
+    //    pub module_call: bool,
     /// If true, calling JS function from native function.
-    pub escape: bool,
+    //    pub escape: bool,
     pub variable_environment: LexicalEnvironmentRef,
     pub lexical_environment: LexicalEnvironmentRef,
     pub saved_lexical_environment: Vec<LexicalEnvironmentRef>,
@@ -76,8 +77,7 @@ impl ExecContext {
             exception_table,
             this,
             constructor_call: false,
-            module_call: false,
-            escape: false,
+            call_mode: CallMode::OrdinaryCall,
             variable_environment: var_env,
             lexical_environment: lex_env,
             saved_lexical_environment: vec![],
@@ -94,8 +94,7 @@ impl ExecContext {
             exception_table: vec![],
             this: Value::undefined(),
             constructor_call: false,
-            module_call: false,
-            escape: false,
+            call_mode: CallMode::OrdinaryCall,
             variable_environment: LexicalEnvironmentRef::new_null(),
             lexical_environment: LexicalEnvironmentRef::new_null(),
             saved_lexical_environment: vec![],
@@ -110,18 +109,8 @@ impl ExecContext {
         &mut *self.lexical_environment
     }
 
-    pub fn escape(mut self) -> Self {
-        self.escape = true;
-        self
-    }
-
     pub fn constructor_call(mut self, is_constructor: bool) -> Self {
         self.constructor_call = is_constructor;
-        self
-    }
-
-    pub fn module_call(mut self, is_module: bool) -> Self {
-        self.module_call = is_module;
         self
     }
 

--- a/src/vm/exec_context.rs
+++ b/src/vm/exec_context.rs
@@ -66,6 +66,7 @@ impl ExecContext {
         lex_env: LexicalEnvironmentRef,
         exception_table: Vec<Exception>,
         this: Value,
+        call_mode: CallMode,
     ) -> Self {
         ExecContext {
             func_id: 0,
@@ -77,7 +78,7 @@ impl ExecContext {
             exception_table,
             this,
             constructor_call: false,
-            call_mode: CallMode::OrdinaryCall,
+            call_mode,
             variable_environment: var_env,
             lexical_environment: lex_env,
             saved_lexical_environment: vec![],

--- a/src/vm/exec_context.rs
+++ b/src/vm/exec_context.rs
@@ -253,7 +253,7 @@ impl LexicalEnvironment {
             },
             EnvironmentRecord::Global(obj) | EnvironmentRecord::Object(obj) => {
                 if obj.has_own_property(name.as_str()) {
-                    let val = obj.get_property_by_str_key(name.as_str());
+                    let val = obj.get_property(name.as_str());
                     if val == Value::uninitialized() {
                         return Err(RuntimeError::reference(format!(
                             "'{}' is not defined",
@@ -287,7 +287,7 @@ impl LexicalEnvironment {
                 None => {}
             },
             EnvironmentRecord::Global(obj) | EnvironmentRecord::Object(obj) => {
-                obj.set_property_by_string_key(name, val);
+                obj.set_property(name, val);
                 return Ok(());
             }
         };
@@ -310,7 +310,7 @@ impl LexicalEnvironment {
                 record.insert(name.into(), val);
             }
             EnvironmentRecord::Global(obj) | EnvironmentRecord::Object(obj) => {
-                obj.set_property_by_string_key(name, val);
+                obj.set_property(name, val);
             }
         };
         return Ok(());

--- a/src/vm/exec_context.rs
+++ b/src/vm/exec_context.rs
@@ -5,7 +5,7 @@ use crate::vm::codegen::FunctionInfo;
 use crate::vm::error::ErrorKind;
 use crate::vm::error::RuntimeError;
 use crate::vm::jsvalue::function::Exception;
-use crate::vm::jsvalue::value::Value;
+use crate::vm::jsvalue::value::{BoxedValue, Value};
 use crate::vm::vm::{Factory, VMResult};
 use rustc_hash::FxHashMap;
 use std::ops::{Deref, DerefMut};
@@ -19,7 +19,7 @@ pub struct ExecContext {
     pub module_func_id: usize,
     pub pc: usize,
     pub current_inst_pc: usize,
-    pub saved_stack_len: usize,
+    pub stack: Vec<BoxedValue>,
     pub bytecode: ByteCode,
     pub exception_table: Vec<Exception>,
     /// This value in the context.
@@ -71,7 +71,7 @@ impl ExecContext {
             module_func_id: 0,
             pc: 0,
             current_inst_pc: 0,
-            saved_stack_len: 0,
+            stack: vec![],
             bytecode,
             exception_table,
             this,
@@ -89,7 +89,7 @@ impl ExecContext {
             module_func_id: 0,
             pc: 0,
             current_inst_pc: 0,
-            saved_stack_len: 0,
+            stack: vec![],
             bytecode: vec![],
             exception_table: vec![],
             this: Value::undefined(),
@@ -122,11 +122,6 @@ impl ExecContext {
 
     pub fn module_call(mut self, is_module: bool) -> Self {
         self.module_call = is_module;
-        self
-    }
-
-    pub fn saved_stack_len(mut self, saved_stack_len: usize) -> Self {
-        self.saved_stack_len = saved_stack_len;
         self
     }
 

--- a/src/vm/exec_context.rs
+++ b/src/vm/exec_context.rs
@@ -83,6 +83,24 @@ impl ExecContext {
             saved_lexical_environment: vec![],
         }
     }
+    pub fn empty() -> Self {
+        ExecContext {
+            func_id: 0,
+            module_func_id: 0,
+            pc: 0,
+            current_inst_pc: 0,
+            saved_stack_len: 0,
+            bytecode: vec![],
+            exception_table: vec![],
+            this: Value::undefined(),
+            constructor_call: false,
+            module_call: false,
+            escape: false,
+            variable_environment: LexicalEnvironmentRef::new_null(),
+            lexical_environment: LexicalEnvironmentRef::new_null(),
+            saved_lexical_environment: vec![],
+        }
+    }
 
     pub fn lex_env(&self) -> &LexicalEnvironment {
         &*self.lexical_environment

--- a/src/vm/factory.rs
+++ b/src/vm/factory.rs
@@ -1,0 +1,138 @@
+use crate::builtin::BuiltinFuncTy;
+use crate::gc;
+use crate::vm::{
+    jsvalue::prototype::ObjectPrototypes,
+    jsvalue::value::{
+        ArrayObjectInfo, ErrorObjectInfo, FunctionObjectInfo, FunctionObjectKind, ObjectInfo,
+        ObjectKind, Property, SymbolInfo, UserFunctionInfo, Value,
+    },
+};
+use rustc_hash::FxHashMap;
+
+#[derive(Debug)]
+pub struct Factory {
+    pub memory_allocator: gc::MemoryAllocator,
+    pub object_prototypes: ObjectPrototypes,
+}
+
+impl Factory {
+    pub fn new(memory_allocator: gc::MemoryAllocator, object_prototypes: ObjectPrototypes) -> Self {
+        Factory {
+            memory_allocator,
+            object_prototypes,
+        }
+    }
+
+    pub fn alloc<T: gc::GcTarget + 'static>(&mut self, data: T) -> *mut T {
+        self.memory_allocator.alloc(data)
+    }
+
+    /// Generate Value for a string.
+    pub fn string(&mut self, body: impl Into<String>) -> Value {
+        Value::String(self.alloc(std::ffi::CString::new(body.into()).unwrap()))
+    }
+
+    /// Generate Value for an object.
+    pub fn object(&mut self, property: FxHashMap<String, Property>) -> Value {
+        Value::Object(self.alloc(ObjectInfo {
+            kind: ObjectKind::Ordinary,
+            prototype: self.object_prototypes.object,
+            property,
+            sym_property: FxHashMap::default(),
+        }))
+    }
+
+    /// Generate Value for a JS function.
+    pub fn function(&mut self, name: Option<String>, info: UserFunctionInfo) -> Value {
+        let name_prop = self.string(name.clone().unwrap_or("".to_string()));
+        let prototype = self.object(FxHashMap::default());
+
+        let f = Value::Object(self.alloc(ObjectInfo {
+            prototype: self.object_prototypes.function,
+            property: make_property_map!(
+                length    => false, false, true : Value::Number(info.params.len() as f64), /* TODO: rest param */
+                name      => false, false, true : name_prop,
+                prototype => true , false, false: prototype
+            ),
+            kind: ObjectKind::Function(FunctionObjectInfo {
+                name: name,
+                kind: FunctionObjectKind::User(info)
+            }),
+            sym_property: FxHashMap::default(),
+        }));
+
+        f.get_property("prototype")
+            .get_object_info()
+            .property
+            .insert("constructor".to_string(), Property::new_data_simple(f));
+
+        f
+    }
+
+    /// Generate Value for a built-in (native) function.
+    pub fn builtin_function(
+        &mut self,
+        name: impl Into<String>,
+        func: crate::builtin::BuiltinFuncTy,
+    ) -> Value {
+        let name: String = name.into();
+        let name_prop = self.string(name.clone());
+        Value::Object(self.alloc(ObjectInfo {
+            kind: ObjectKind::Function(FunctionObjectInfo {
+                name: Some(name),
+                kind: FunctionObjectKind::Builtin(func),
+            }),
+            prototype: self.object_prototypes.function,
+            property: make_property_map!(
+                length => false, false, true : Value::Number(0.0),
+                name   => false, false, true : name_prop
+            ),
+            sym_property: FxHashMap::default(),
+        }))
+    }
+
+    pub fn array(&mut self, elems: Vec<Property>) -> Value {
+        Value::Object(self.alloc(ObjectInfo {
+            kind: ObjectKind::Array(ArrayObjectInfo { elems }),
+            prototype: self.object_prototypes.array,
+            property: make_property_map!(),
+            sym_property: FxHashMap::default(),
+        }))
+    }
+
+    pub fn symbol(&mut self, description: Option<String>) -> Value {
+        Value::Object(self.alloc(ObjectInfo {
+            kind: ObjectKind::Symbol(SymbolInfo {
+                id: crate::id::get_unique_id(),
+                description,
+            }),
+            prototype: self.object_prototypes.symbol,
+            property: make_property_map!(),
+            sym_property: FxHashMap::default(),
+        }))
+    }
+
+    pub fn error(&mut self, message: impl Into<String>) -> Value {
+        let message = self.string(message.into());
+        Value::Object(self.alloc(ObjectInfo {
+            kind: ObjectKind::Error(ErrorObjectInfo::new()),
+            prototype: self.object_prototypes.error,
+            property: make_property_map!(
+                message => true, false, true: message
+            ),
+            sym_property: FxHashMap::default(),
+        }))
+    }
+
+    pub fn generate_builtin_constructor(
+        &mut self,
+        constructor_name: impl Into<String>,
+        constructor_func: BuiltinFuncTy,
+        prototype: Value,
+    ) -> Value {
+        let ary = self.builtin_function(constructor_name, constructor_func);
+        ary.set_property("prototype", prototype);
+        ary.get_property("prototype").set_constructor(ary);
+        ary
+    }
+}

--- a/src/vm/jsvalue/array.rs
+++ b/src/vm/jsvalue/array.rs
@@ -1,4 +1,4 @@
-// use super::super::frame::LexicalEnvironmentRef;
+// use super::super::context::LexicalEnvironmentRef;
 use super::value::*;
 // use builtin::BuiltinFuncTy;
 // use bytecode_gen::ByteCode;

--- a/src/vm/jsvalue/object.rs
+++ b/src/vm/jsvalue/object.rs
@@ -73,7 +73,7 @@ impl ObjectInfo {
         self.prototype
     }
 
-    pub fn get_property(
+    pub fn get_property_by_value(
         &self,
         factory: &mut Factory,
         key: Value,
@@ -87,7 +87,7 @@ impl ObjectInfo {
             let id = key.get_symbol_info().id;
             return match self.sym_property.get(&id) {
                 Some(prop) => Ok(*prop),
-                None => self.prototype.get_property(factory, key),
+                None => self.prototype.get_property_by_value(factory, key),
             };
         }
 
@@ -119,19 +119,19 @@ impl ObjectInfo {
                 if proto.is_null() {
                     return Ok(Property::new_data_simple(Value::undefined()));
                 };
-                proto.get_property(factory, key)
+                proto.get_property_by_value(factory, key)
             }
         }
     }
 
-    pub fn get_property_by_str_key(&self, key: &str) -> Value {
+    pub fn get_property(&self, key: &str) -> Value {
         match self.property.get(key) {
             Some(prop) => prop.as_data().val,
-            None => self.prototype.get_property_by_str_key(key),
+            None => self.prototype.get_property(key),
         }
     }
 
-    pub fn set_property_by_string_key(&mut self, key: String, val: Value) {
+    pub fn set_property(&mut self, key: String, val: Value) {
         let property = self
             .property
             .entry(key)
@@ -142,7 +142,7 @@ impl ObjectInfo {
         }
     }
 
-    pub fn set_property(
+    pub fn set_property_by_value(
         &mut self,
         allocator: &mut MemoryAllocator,
         key: Value,

--- a/src/vm/jsvalue/value.rs
+++ b/src/vm/jsvalue/value.rs
@@ -326,14 +326,14 @@ impl Value {
         }
     }
 
-    pub fn get_property_by_str_key(&self, key: &str) -> Value {
+    pub fn get_property(&self, key: &str) -> Value {
         match self {
-            Value::Object(obj_info) => ObjectRef(*obj_info).get_property_by_str_key(key),
+            Value::Object(obj_info) => ObjectRef(*obj_info).get_property(key),
             _ => Value::undefined(),
         }
     }
 
-    pub fn get_property(
+    pub fn get_property_by_value(
         &self,
         factory: &mut Factory,
         key: Value,
@@ -354,7 +354,7 @@ impl Value {
                     .object_prototypes
                     .string
                     .get_object_info()
-                    .get_property(factory, key),
+                    .get_property_by_value(factory, key),
             }
         }
 
@@ -374,28 +374,28 @@ impl Value {
         }
 
         match self {
-            Value::Object(obj_info) => ObjectRef(*obj_info).get_property(factory, key),
+            Value::Object(obj_info) => ObjectRef(*obj_info).get_property_by_value(factory, key),
             _ => Ok(Property::new_data_simple(Value::undefined())),
         }
     }
 
-    pub fn set_property_by_string_key(&self, key: impl Into<String>, val: Value) {
+    pub fn set_property(&self, key: impl Into<String>, val: Value) {
         match self {
-            Value::Object(obj_info) => {
-                ObjectRef(*obj_info).set_property_by_string_key(key.into(), val)
-            }
+            Value::Object(obj_info) => ObjectRef(*obj_info).set_property(key.into(), val),
             _ => {}
         }
     }
 
-    pub fn set_property(
+    pub fn set_property_by_value(
         &self,
         allocator: &mut gc::MemoryAllocator,
         key: Value,
         val: Value,
     ) -> Result<Option<Value>, error::RuntimeError> {
         match self {
-            Value::Object(obj_info) => ObjectRef(*obj_info).set_property(allocator, key, val),
+            Value::Object(obj_info) => {
+                ObjectRef(*obj_info).set_property_by_value(allocator, key, val)
+            }
             Value::Other(_) => Err(error::RuntimeError::typeerr(format!(
                 "TypeError: Cannot set property '{}' of {}",
                 key.to_string(),
@@ -986,10 +986,9 @@ impl Value {
                         "Symbol({})",
                         info.description.as_ref().unwrap_or(&"".to_string())
                     ),
-                    ObjectKind::Error(ref _info) => format!(
-                        "Error({})",
-                        obj_info.get_property_by_str_key("message").to_string()
-                    ),
+                    ObjectKind::Error(ref _info) => {
+                        format!("Error({})", obj_info.get_property("message").to_string())
+                    }
                     ObjectKind::Function(ref func_info) => {
                         if let Some(ref name) = func_info.name {
                             format!("[Function: {}]", name)

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -4,4 +4,5 @@ pub mod codegen;
 pub mod constant;
 pub mod error;
 pub mod exec_context;
+pub mod factory;
 pub mod vm;

--- a/test.js
+++ b/test.js
@@ -1,3 +1,3 @@
-throw new Error('abscent')
+//throw new Error('abscent')
 let a = [1, 2, 3, [4, 5], 5]
 a(400)

--- a/test/accessor_property.js
+++ b/test/accessor_property.js
@@ -1,4 +1,4 @@
-let assert = require('./assert.js').deepStrictEqual
+let assert = require('assert').deepStrictEqual
 let obj = {
   _x: 7,
   get x() {

--- a/test/array.js
+++ b/test/array.js
@@ -1,4 +1,4 @@
-let assert = require('./assert.js').deepStrictEqual
+let assert = require('assert').deepStrictEqual
 
 var a = [1, 2, 'three', 4]
 assert(a[2], 'three')

--- a/test/closure.js
+++ b/test/closure.js
@@ -1,4 +1,4 @@
-var assert = require('./assert.js').deepStrictEqual
+var assert = require('assert').deepStrictEqual
 count = 1000
 var mod = (function() {
   var count = 0

--- a/test/fibo.js
+++ b/test/fibo.js
@@ -1,8 +1,8 @@
 let assert = require('assert').deepStrictEqual
 
-function fibo(x) {
+function fibo (x) {
   if (x < 2) return 1
   return fibo(x - 1) + fibo(x - 2)
 }
 
-assert(fibo(20), 10946)
+assert(fibo(10), 89)

--- a/test/fibo.js
+++ b/test/fibo.js
@@ -1,4 +1,4 @@
-let assert = require('./assert.js').deepStrictEqual
+let assert = require('assert').deepStrictEqual
 
 function fibo(x) {
   if (x < 2) return 1

--- a/test/function_methods.js
+++ b/test/function_methods.js
@@ -1,4 +1,4 @@
-let assert = require('assert.js').deepStrictEqual
+let assert = require('assert').deepStrictEqual
 
 function Product(name, price) {
   this.name = name

--- a/test/function_methods.js
+++ b/test/function_methods.js
@@ -1,0 +1,14 @@
+let assert = require('assert.js').deepStrictEqual
+
+function Product(name, price) {
+  this.name = name
+  this.price = price
+}
+
+function Food(name, price) {
+  Product.call(this, name, price)
+  this.category = 'food'
+}
+
+assert(new Food('cheese', 5).name, 'cheese')
+// expected output: "cheese"

--- a/test/prototypes.js
+++ b/test/prototypes.js
@@ -1,4 +1,4 @@
-var assert = require('./assert.js').deepStrictEqual
+var assert = require('assert').deepStrictEqual
 
 assert(Object.prototype.constructor === Object, true)
 assert(Function.prototype.constructor === Function, true)

--- a/test/string_methods.js
+++ b/test/string_methods.js
@@ -1,0 +1,3 @@
+let assert = require('assert.js').deepStrictEqual
+assert('thereisapencil'.split('e'), ['th', 'r', 'isap', 'ncil'])
+assert('thereisapencil'.indexOf('pen'), 8)

--- a/test/string_methods.js
+++ b/test/string_methods.js
@@ -1,3 +1,3 @@
-let assert = require('assert.js').deepStrictEqual
+let assert = require('assert').deepStrictEqual
 assert('thereisapencil'.split('e'), ['th', 'r', 'isap', 'ncil'])
 assert('thereisapencil'.indexOf('pen'), 8)

--- a/test/test_module.js
+++ b/test/test_module.js
@@ -1,0 +1,9 @@
+let count = 10
+module.exports = {
+  countup: x => {
+    count += x
+  },
+  count: () => {
+    return count
+  }
+}

--- a/test/test_module_caller.js
+++ b/test/test_module_caller.js
@@ -1,0 +1,3 @@
+let mod = require('./test/test_module.js')
+mod.countup(5)
+if (mod.count() !== 15) throw new Error()

--- a/test/trinity.js
+++ b/test/trinity.js
@@ -1,4 +1,4 @@
-let assert = require('./assert.js').deepStrictEqual
+let assert = require('assert').deepStrictEqual
 // Simple assert ever
 
 assert([] == 0, true)

--- a/test/trycatch.js
+++ b/test/trycatch.js
@@ -1,4 +1,4 @@
-let assert = require('./assert.js').deepStrictEqual
+let assert = require('assert').deepStrictEqual
 
 var a = []
 const b = 1


### PR DESCRIPTION
This PR is a proposal for refactoring.
- "frame" is renamed to "context".
- Move `current_context` (formerly `cur_frame`) into `VM` struct.
- Execution stack is moved from the VM struct to each of execution contexts.
This will be necessary for concurrent execution of two or more contexts in the future.
- `Factory` module is separated from `VM` module.
- Add tests for module (`require()`), `Function` and `String` prototype methods.