### PR TITLE
Implement spread operator for array literal.

### DIFF
--- a/src/bytecode_gen.rs
+++ b/src/bytecode_gen.rs
@@ -91,8 +91,12 @@ impl<'a> ByteCodeGenerator<'a> {
         iseq.push(VMInst::PUSH_UNDEFINED);
     }
 
-    pub fn append_spread(&self, iseq: &mut ByteCode) {
-        iseq.push(VMInst::SPREAD);
+    pub fn append_spread_array(&self, iseq: &mut ByteCode) {
+        iseq.push(VMInst::SPREAD_ARRAY);
+    }
+
+    pub fn append_spread_obj(&self, iseq: &mut ByteCode) {
+        iseq.push(VMInst::SPREAD_OBJ);
     }
 
     pub fn append_lnot(&self, iseq: &mut ByteCode) {
@@ -466,7 +470,8 @@ pub fn inst_to_inst_name(inst: u8) -> &'static str {
         VMInst::TYPEOF => "Typeof",
         VMInst::EXP => "Exp",
         VMInst::PUSH_SEPERATOR => "PushSeperator",
-        VMInst::SPREAD => "Spread",
+        VMInst::SPREAD_ARRAY => "SpreadArray",
+        VMInst::SPREAD_OBJ => "SpreadObj",
         _ => "???",
     }
 }
@@ -486,7 +491,8 @@ pub mod VMInst {
     pub const PUSH_ARGUMENTS: u8 = 0x0b;
     pub const PUSH_UNDEFINED: u8 = 0x0c;
     pub const PUSH_SEPERATOR: u8 = 0x01;
-    pub const SPREAD: u8 = 0x48;
+    pub const SPREAD_ARRAY: u8 = 0x48;
+    pub const SPREAD_OBJ: u8 = 0x49;
     pub const DOUBLE: u8 = 0x29;
     pub const POP: u8 = 0x2a;
     pub const LNOT: u8 = 0x0d;
@@ -549,9 +555,8 @@ pub mod VMInst {
             PUSH_FALSE | END | PUSH_TRUE | PUSH_THIS | ADD | SUB | MUL | DIV | REM | LT | EXP
             | PUSH_ARGUMENTS | NEG | POSI | GT | LE | GE | EQ | NE | GET_MEMBER | RETURN | SNE
             | ZFSHR | POP | DOUBLE | AND | COND_OP | OR | SEQ | SET_MEMBER | LNOT
-            | PUSH_UNDEFINED | LAND | SHR | SHL | XOR | LOR | NOT | CREATE_ARRAY | SPREAD => {
-                Some(1)
-            }
+            | PUSH_UNDEFINED | LAND | SHR | SHL | XOR | LOR | NOT | CREATE_ARRAY | SPREAD_ARRAY
+            | SPREAD_OBJ => Some(1),
             _ => None,
         }
     }

--- a/src/bytecode_gen.rs
+++ b/src/bytecode_gen.rs
@@ -27,9 +27,8 @@ impl<'a> ByteCodeGenerator<'a> {
         self.append_int32(len as i32, iseq);
     }
 
-    pub fn append_create_array(&self, len: usize, iseq: &mut ByteCode) {
+    pub fn append_create_array(&self, iseq: &mut ByteCode) {
         iseq.push(VMInst::CREATE_ARRAY);
-        self.append_int32(len as i32, iseq);
     }
 
     pub fn append_push_int8(&self, n: i8, iseq: &mut ByteCode) {
@@ -76,6 +75,10 @@ impl<'a> ByteCodeGenerator<'a> {
         iseq.push(VMInst::PUSH_NULL);
     }
 
+    pub fn append_push_seperator(&self, iseq: &mut ByteCode) {
+        iseq.push(VMInst::PUSH_SEPERATOR);
+    }
+
     pub fn append_push_this(&self, iseq: &mut ByteCode) {
         iseq.push(VMInst::PUSH_THIS);
     }
@@ -86,6 +89,10 @@ impl<'a> ByteCodeGenerator<'a> {
 
     pub fn append_push_undefined(&self, iseq: &mut ByteCode) {
         iseq.push(VMInst::PUSH_UNDEFINED);
+    }
+
+    pub fn append_spread(&self, iseq: &mut ByteCode) {
+        iseq.push(VMInst::SPREAD);
     }
 
     pub fn append_lnot(&self, iseq: &mut ByteCode) {
@@ -324,10 +331,6 @@ pub fn show_inst(code: &ByteCode, i: usize, const_table: &constant::ConstantTabl
                 let int32 = read_int32(code, i + 1);
                 format!("CreateObject {}", int32)
             }
-            VMInst::CREATE_ARRAY => {
-                let int32 = read_int32(code, i + 1);
-                format!("CreateArray {}", int32)
-            }
             VMInst::PUSH_INT8 => {
                 let int8 = code[i + 1] as i32;
                 format!("PushInt8 {}", int8)
@@ -350,11 +353,6 @@ pub fn show_inst(code: &ByteCode, i: usize, const_table: &constant::ConstantTabl
                 let int32 = read_int32(code, i + 1);
                 format!("Jmp {:05}", i as i32 + int32 + 5)
             }
-            /*VMInst::JMP_UNWIND => {
-                let dest = read_int32(code, i + 1);
-                let pop = read_int32(code, i + 5);
-                format!("JmpUnwind {:05} {}", i as i32 + dest + 5, pop)
-            }*/
             VMInst::CALL => {
                 let int32 = read_int32(code, i + 1);
                 format!("Call {}", int32)
@@ -363,12 +361,6 @@ pub fn show_inst(code: &ByteCode, i: usize, const_table: &constant::ConstantTabl
                 let int32 = read_int32(code, i + 1);
                 format!("CallMethod {}", int32)
             }
-            VMInst::RETURN => format!("Return"),
-            VMInst::DOUBLE => format!("Double"),
-            VMInst::POP => format!("Pop"),
-            VMInst::LAND => format!("LogAnd"),
-            VMInst::LOR => format!("LogOr"),
-            //VMInst::UPDATE_PARENT_SCOPE => format!("UpdateParentScope"),
             VMInst::GET_VALUE => {
                 let int32 = read_int32(code, i + 1);
                 let name = const_table.get(int32 as usize).as_string();
@@ -473,6 +465,8 @@ pub fn inst_to_inst_name(inst: u8) -> &'static str {
         VMInst::RETURN_SUB => "ReturnSub",
         VMInst::TYPEOF => "Typeof",
         VMInst::EXP => "Exp",
+        VMInst::PUSH_SEPERATOR => "PushSeperator",
+        VMInst::SPREAD => "Spread",
         _ => "???",
     }
 }
@@ -491,6 +485,8 @@ pub mod VMInst {
     pub const PUSH_THIS: u8 = 0x0a;
     pub const PUSH_ARGUMENTS: u8 = 0x0b;
     pub const PUSH_UNDEFINED: u8 = 0x0c;
+    pub const PUSH_SEPERATOR: u8 = 0x01;
+    pub const SPREAD: u8 = 0x48;
     pub const DOUBLE: u8 = 0x29;
     pub const POP: u8 = 0x2a;
     pub const LNOT: u8 = 0x0d;
@@ -546,14 +542,16 @@ pub mod VMInst {
     pub fn get_inst_size(inst: u8) -> Option<usize> {
         match inst {
             THROW | RETURN_SUB | SET_OUTER_ENV | POP_ENV | TYPEOF | PUSH_NULL => Some(1),
-            CONSTRUCT | CREATE_OBJECT | PUSH_CONST | PUSH_INT32 | CREATE_ARRAY | JMP_IF_FALSE
-            | RETURN_TRY | DECL_VAR | LOOP_START | JMP | SET_VALUE | GET_VALUE | CALL | JMP_SUB
+            CONSTRUCT | CREATE_OBJECT | PUSH_CONST | PUSH_INT32 | JMP_IF_FALSE | RETURN_TRY
+            | DECL_VAR | LOOP_START | JMP | SET_VALUE | GET_VALUE | CALL | JMP_SUB
             | CALL_METHOD | PUSH_ENV | DECL_LET | DECL_CONST => Some(5),
             PUSH_INT8 => Some(2),
             PUSH_FALSE | END | PUSH_TRUE | PUSH_THIS | ADD | SUB | MUL | DIV | REM | LT | EXP
             | PUSH_ARGUMENTS | NEG | POSI | GT | LE | GE | EQ | NE | GET_MEMBER | RETURN | SNE
             | ZFSHR | POP | DOUBLE | AND | COND_OP | OR | SEQ | SET_MEMBER | LNOT
-            | PUSH_UNDEFINED | LAND | SHR | SHL | XOR | LOR | NOT => Some(1),
+            | PUSH_UNDEFINED | LAND | SHR | SHL | XOR | LOR | NOT | CREATE_ARRAY | SPREAD => {
+                Some(1)
+            }
             _ => None,
         }
     }

--- a/src/bytecode_gen.rs
+++ b/src/bytecode_gen.rs
@@ -95,10 +95,6 @@ impl<'a> ByteCodeGenerator<'a> {
         iseq.push(VMInst::SPREAD_ARRAY);
     }
 
-    pub fn append_spread_obj(&self, iseq: &mut ByteCode) {
-        iseq.push(VMInst::SPREAD_OBJ);
-    }
-
     pub fn append_lnot(&self, iseq: &mut ByteCode) {
         iseq.push(VMInst::LNOT);
     }
@@ -471,7 +467,6 @@ pub fn inst_to_inst_name(inst: u8) -> &'static str {
         VMInst::EXP => "Exp",
         VMInst::PUSH_SEPERATOR => "PushSeperator",
         VMInst::SPREAD_ARRAY => "SpreadArray",
-        VMInst::SPREAD_OBJ => "SpreadObj",
         _ => "???",
     }
 }
@@ -492,7 +487,6 @@ pub mod VMInst {
     pub const PUSH_UNDEFINED: u8 = 0x0c;
     pub const PUSH_SEPERATOR: u8 = 0x01;
     pub const SPREAD_ARRAY: u8 = 0x48;
-    pub const SPREAD_OBJ: u8 = 0x49;
     pub const DOUBLE: u8 = 0x29;
     pub const POP: u8 = 0x2a;
     pub const LNOT: u8 = 0x0d;
@@ -555,8 +549,9 @@ pub mod VMInst {
             PUSH_FALSE | END | PUSH_TRUE | PUSH_THIS | ADD | SUB | MUL | DIV | REM | LT | EXP
             | PUSH_ARGUMENTS | NEG | POSI | GT | LE | GE | EQ | NE | GET_MEMBER | RETURN | SNE
             | ZFSHR | POP | DOUBLE | AND | COND_OP | OR | SEQ | SET_MEMBER | LNOT
-            | PUSH_UNDEFINED | LAND | SHR | SHL | XOR | LOR | NOT | CREATE_ARRAY | SPREAD_ARRAY
-            | SPREAD_OBJ => Some(1),
+            | PUSH_UNDEFINED | LAND | SHR | SHL | XOR | LOR | NOT | CREATE_ARRAY | SPREAD_ARRAY => {
+                Some(1)
+            }
             _ => None,
         }
     }

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -618,7 +618,7 @@ impl Lexer {
             '.' => {
                 if self.take_char_if('.')? {
                     symbol = if self.take_char_if('.')? {
-                        Symbol::Rest
+                        Symbol::Spread
                     } else {
                         return Err(Error::General(pos, "Invalid token".to_string()));
                     }

--- a/src/node.rs
+++ b/src/node.rs
@@ -25,6 +25,7 @@ pub enum PropertyDefinition {
     IdentifierReference(String),
     Property(String, Node),
     MethodDefinition(MethodDefinitionKind, String, Node),
+    Spread(String),
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -75,7 +76,7 @@ pub enum NodeBase {
     Array(Vec<Node>),
     Object(Vec<PropertyDefinition>),
     Identifier(String),
-    Spread(String),
+    Spread(Box<Node>),
     This,
     // Arguments,
     // Undefined,

--- a/src/node.rs
+++ b/src/node.rs
@@ -25,7 +25,7 @@ pub enum PropertyDefinition {
     IdentifierReference(String),
     Property(String, Node),
     MethodDefinition(MethodDefinitionKind, String, Node),
-    Spread(String),
+    Spread(Node),
 }
 
 #[derive(Clone, Debug, PartialEq)]

--- a/src/node.rs
+++ b/src/node.rs
@@ -25,7 +25,7 @@ pub enum PropertyDefinition {
     IdentifierReference(String),
     Property(String, Node),
     MethodDefinition(MethodDefinitionKind, String, Node),
-    Spread(Node),
+    SpreadObject(Node),
 }
 
 #[derive(Clone, Debug, PartialEq)]

--- a/src/node.rs
+++ b/src/node.rs
@@ -75,6 +75,7 @@ pub enum NodeBase {
     Array(Vec<Node>),
     Object(Vec<PropertyDefinition>),
     Identifier(String),
+    Spread(String),
     This,
     // Arguments,
     // Undefined,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1158,13 +1158,13 @@ impl Parser {
                 return Err(Error::UnexpectedEOF("']' may be needed".to_string()));
             }
 
-            if self.lexer.next_if(Kind::Symbol(Symbol::Spread)) {
-                let ident = self.lexer.next_skip_lineterminator()?;
-                if let Kind::Identifier(name) = ident.kind {
-                    elements.push(Node::new(NodeBase::Spread(name), ident.pos));
-                } else {
-                    return Err(Error::Expect(ident.pos, "Expect identifier.".to_string()));
-                }
+            if self
+                .lexer
+                .next_if_skip_lineterminator(Kind::Symbol(Symbol::Spread))?
+            {
+                let node = self.read_assignment_expression()?;
+                let pos = node.pos;
+                elements.push(Node::new(NodeBase::Spread(Box::new(node)), pos));
             } else {
                 elements.push(self.read_assignment_expression()?);
             }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1221,6 +1221,14 @@ impl Parser {
             }
         }
 
+        if self
+            .lexer
+            .next_if_skip_lineterminator(Kind::Symbol(Symbol::Spread))?
+        {
+            let node = self.read_assignment_expression()?;
+            return Ok(PropertyDefinition::Spread(node));
+        }
+
         let tok = self.lexer.next_skip_lineterminator()?;
 
         if self

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1226,7 +1226,7 @@ impl Parser {
             .next_if_skip_lineterminator(Kind::Symbol(Symbol::Spread))?
         {
             let node = self.read_assignment_expression()?;
-            return Ok(PropertyDefinition::Spread(node));
+            return Ok(PropertyDefinition::SpreadObject(node));
         }
 
         let tok = self.lexer.next_skip_lineterminator()?;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1159,7 +1159,7 @@ impl Parser {
             }
 
             if self.lexer.next_if(Kind::Symbol(Symbol::Spread)) {
-                let ident = self.lexer.peek_skip_lineterminator()?;
+                let ident = self.lexer.next_skip_lineterminator()?;
                 if let Kind::Identifier(name) = ident.kind {
                     elements.push(Node::new(NodeBase::Spread(name), ident.pos));
                 } else {

--- a/src/token.rs
+++ b/src/token.rs
@@ -108,7 +108,7 @@ pub enum Symbol {
     AssignLAnd,
     AssignLOr,
     Hash,
-    Rest,
+    Spread,
     FatArrow,
 }
 

--- a/src/vm/codegen.rs
+++ b/src/vm/codegen.rs
@@ -185,8 +185,8 @@ impl<'a> CodeGenerator<'a> {
                     self.bytecode_generator.append_pop(iseq);
                 }
             }
-            NodeBase::Spread(ref name) => {
-                self.bytecode_generator.append_get_value(name, iseq);
+            NodeBase::Spread(ref node) => {
+                self.visit(node, iseq, true)?;
                 if !use_value {
                     self.bytecode_generator.append_pop(iseq);
                 } else {
@@ -1091,6 +1091,9 @@ impl<'a> CodeGenerator<'a> {
                     self.visit(&node, iseq, true)?;
                     self.bytecode_generator
                         .append_push_const(self.factory.string(name.clone()), iseq);
+                }
+                PropertyDefinition::Spread(_node) => {
+                    unimplemented!();
                 }
             }
         }

--- a/src/vm/codegen.rs
+++ b/src/vm/codegen.rs
@@ -190,7 +190,7 @@ impl<'a> CodeGenerator<'a> {
                 if !use_value {
                     self.bytecode_generator.append_pop(iseq);
                 } else {
-                    self.bytecode_generator.append_spread(iseq);
+                    self.bytecode_generator.append_spread_array(iseq);
                 }
             }
             NodeBase::Null => {
@@ -1092,8 +1092,10 @@ impl<'a> CodeGenerator<'a> {
                     self.bytecode_generator
                         .append_push_const(self.factory.string(name.clone()), iseq);
                 }
-                PropertyDefinition::Spread(_node) => {
-                    unimplemented!();
+                PropertyDefinition::Spread(node) => {
+                    special_properties.insert(len - i - 1, SpecialPropertyKind::Spread);
+                    self.visit(&node, iseq, true)?;
+                    self.bytecode_generator.append_push_null(iseq);
                 }
             }
         }

--- a/src/vm/codegen.rs
+++ b/src/vm/codegen.rs
@@ -1061,6 +1061,7 @@ impl<'a> CodeGenerator<'a> {
         properties: &Vec<PropertyDefinition>,
         iseq: &mut ByteCode,
     ) -> CodeGenResult {
+        self.bytecode_generator.append_push_seperator(iseq);
         let mut special_properties = SpecialProperties::default();
         let len = properties.len();
 

--- a/src/vm/constant.rs
+++ b/src/vm/constant.rs
@@ -20,6 +20,7 @@ pub type SpecialProperties = FxHashMap<usize, SpecialPropertyKind>;
 pub enum SpecialPropertyKind {
     Getter,
     Setter,
+    Spread,
 }
 
 #[derive(Clone, Debug, PartialEq)]

--- a/src/vm/jsvalue/value.rs
+++ b/src/vm/jsvalue/value.rs
@@ -16,6 +16,7 @@ pub const UNINITIALIZED: i32 = 0;
 pub const EMPTY: i32 = 1;
 pub const NULL: i32 = 2;
 pub const UNDEFINED: i32 = 3;
+pub const SEPERATOR: i32 = 4;
 
 #[derive(Debug, Clone, PartialEq, Copy)]
 pub enum PreferredType {
@@ -126,6 +127,7 @@ impl std::fmt::Display for Value {
             Value::Other(EMPTY) => write!(f, "UNINITIALIZED"),
             Value::Other(NULL) => write!(f, "NULL"),
             Value::Other(UNDEFINED) => write!(f, "UNDEFINED"),
+            Value::Other(SEPERATOR) => write!(f, "SEPERATER"),
             Value::Other(i) => write!(f, "Other({})", i),
             Value::Object(ref info) => {
                 let info = ObjectRef(*info);
@@ -142,20 +144,29 @@ impl std::fmt::Display for Value {
 }
 
 impl Value {
+    #[inline]
     pub const fn null() -> Self {
         Value::Other(NULL)
     }
 
+    #[inline]
     pub const fn undefined() -> Self {
         Value::Other(UNDEFINED)
     }
 
+    #[inline]
     pub const fn uninitialized() -> Self {
         Value::Other(UNINITIALIZED)
     }
 
+    #[inline]
     pub const fn empty() -> Self {
         Value::Other(EMPTY)
+    }
+
+    #[inline]
+    pub const fn seperator() -> Self {
+        Value::Other(SEPERATOR)
     }
 
     #[inline]
@@ -208,6 +219,13 @@ impl Value {
     pub fn is_empty(&self) -> bool {
         match self {
             Value::Other(EMPTY) => true,
+            _ => false,
+        }
+    }
+
+    pub fn is_seperator(&self) -> bool {
+        match self {
+            Value::Other(SEPERATOR) => true,
             _ => false,
         }
     }

--- a/src/vm/vm.rs
+++ b/src/vm/vm.rs
@@ -1021,11 +1021,15 @@ impl VM {
     }
 
     fn create_object(&mut self, id: usize) -> VMResult {
-        let (len, special_properties) = self.constant_table.get(id).as_object_literal_info();
+        let (_, special_properties) = self.constant_table.get(id).as_object_literal_info();
         let mut properties = FxHashMap::default();
 
-        for i in 0..len {
+        let mut i = 0;
+        loop {
             let prop: Value = self.current_context.stack.pop().unwrap().into();
+            if prop.is_seperator() {
+                break;
+            }
             let name = prop.to_string();
             let val: Value = self.current_context.stack.pop().unwrap().into();
             if let Some(kind) = special_properties.get(&i) {
@@ -1055,6 +1059,7 @@ impl VM {
                     }),
                 );
             }
+            i += 1;
         }
 
         let obj = self.factory.object(properties);

--- a/src/vm/vm.rs
+++ b/src/vm/vm.rs
@@ -663,7 +663,6 @@ impl VM {
                         self.current_context.stack.push(val.into());
                     }
                 }
-                VMInst::SPREAD_OBJ => {}
                 VMInst::GET_MEMBER => {
                     self.current_context.pc += 1;
                     let property: Value = self.current_context.stack.pop().unwrap().into();
@@ -1022,7 +1021,7 @@ impl VM {
     }
 
     fn create_object(&mut self, id: usize) -> VMResult {
-        let (_, special_properties) = self.constant_table.get(id).as_object_literal_info();
+        let special_properties = self.constant_table.get(id).as_object_literal_info();
         let mut properties = FxHashMap::default();
 
         let mut i = 0;

--- a/tests/test/spread_op.js
+++ b/tests/test/spread_op.js
@@ -1,0 +1,9 @@
+let assert = require('assert').deepStrictEqual
+
+let a = [1, 2]
+let b = [4, 5]
+
+assert([0, ...a, 3], [0, 1, 2, 3])
+assert([...a, 3], [1, 2, 3])
+assert([0, ...a], [0, 1, 2])
+assert([0, ...a, ...b, 6], [0, 1, 2, 4, 5, 6])

--- a/tests/test/spread_op.js
+++ b/tests/test/spread_op.js
@@ -2,8 +2,10 @@ let assert = require('assert').deepStrictEqual
 
 let a = [1, 2]
 let b = [4, 5]
+let c = { a, b }
 
 assert([0, ...a, 3], [0, 1, 2, 3])
 assert([...a, 3], [1, 2, 3])
 assert([0, ...a], [0, 1, 2])
 assert([0, ...a, ...b, 6], [0, 1, 2, 4, 5, 6])
+assert([0, ...c.b, ...c.a, 6], [0, 4, 5, 1, 2, 6])

--- a/tests/test/spread_op.js
+++ b/tests/test/spread_op.js
@@ -9,3 +9,10 @@ assert([...a, 3], [1, 2, 3])
 assert([0, ...a], [0, 1, 2])
 assert([0, ...a, ...b, 6], [0, 1, 2, 4, 5, 6])
 assert([0, ...c.b, ...c.a, 6], [0, 4, 5, 1, 2, 6])
+
+let d = { dx: 0, dy: 1 }
+a.foo = 13
+
+assert({ ea: 7, ...d, eb: 9 }, { ea: 7, dx: 0, dy: 1, eb: 9 })
+assert({ fa: 7, ...d, fb: 9, dy: 10 }, { fa: 7, dx: 0, fb: 9, dy: 10 })
+assert({ bar: 17, ...a }, { "0": 1, "1": 2, bar: 17, foo: 13 })

--- a/tests/vm_test.rs
+++ b/tests/vm_test.rs
@@ -188,6 +188,11 @@ fn array() {
 }
 
 #[test]
+fn spread_op() {
+    assert_file("spread_op")
+}
+
+#[test]
 fn env() {
     assert_file("env")
 }


### PR DESCRIPTION
This PR implements spread operator("...") for array literal and object literal.

test code(tests/test/spread_op.js)
```javascript
let assert = require('assert').deepStrictEqual

let a = [1, 2]
let b = [4, 5]
let c = { a, b }

assert([0, ...a, 3], [0, 1, 2, 3])
assert([...a, 3], [1, 2, 3])
assert([0, ...a], [0, 1, 2])
assert([0, ...a, ...b, 6], [0, 1, 2, 4, 5, 6])
assert([0, ...c.b, ...c.a, 6], [0, 4, 5, 1, 2, 6])

let d = { dx: 0, dy: 1 }
a.foo = 13

assert({ ea: 7, ...d, eb: 9 }, { ea: 7, dx: 0, dy: 1, eb: 9 })
assert({ fa: 7, ...d, fb: 9, dy: 10 }, { fa: 7, dx: 0, fb: 9, dy: 10 })
assert({ bar: 17, ...a }, { "0": 1, "1": 2, bar: 17, foo: 13 })
```